### PR TITLE
ログイン、ログアウト処理の実装

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,30 @@
-<h2>Log in</h2>
+<div class="max-w-md mx-auto mt-20 card bg-base-100 shadow-xl">
+  <div class="card-body">
+    <h2 class="text-2xl font-bold text-center mb-4">ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+    <%= form_with model: resource, url: session_path(resource_name), class: "space-y-4" do |f| %>
+      <div>
+        <%= f.label :email, class: "label" %>
+        <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full" %>
+      </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+      <div>
+        <%= f.label :password, class: "label" %>
+        <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered w-full" %>
+      </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <div class="flex justify-between items-center">
+        <%= f.check_box :remember_me, class: "checkbox" %>
+        <%= f.label :remember_me, "ログイン状態を保持" %>
+      </div>
+
+      <div>
+        <%= f.submit "ログイン", class: "btn btn-primary w-full" %>
+      </div>
+    <% end %>
+
+    <div class="text-center mt-4">
+      <%= link_to "新規登録はこちら", new_user_registration_path, class: "link link-primary" %>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,23 +1,24 @@
-<header class="fixed top-0 left-0 right-0 z-50 bg-base-100 shadow-sm border-b overflow-hidden">
-  <!-- 高さは min-h で安定させる（SP: 64px / PC: 80px）-->
+<header class="fixed top-0 left-0 right-0 z-50 bg-base-100 shadow-sm border-b">
+  <!-- 高さは min-h で安定（SP:64px / PC:80px） -->
   <div class="min-h-16 md:min-h-20">
-    <div class="container mx-auto max-w-6xl h-full px-4 md:px-8 flex items-center justify-between gap-3">
+    <div class="container mx-auto max-w-6xl h-full px-4 md:px-8
+                flex items-center justify-between gap-3 flex-nowrap">
 
-      <!-- 左：ブランド -->
-      <%= link_to root_path, class: "btn btn-ghost h-10 min-h-10 px-2 text-xl md:text-2xl font-extrabold leading-none" do %>
+      <!-- 左：ブランド（折り返し禁止） -->
+      <%= link_to root_path, class: "btn btn-ghost h-10 min-h-10 px-2 text-xl md:text-2xl font-extrabold leading-none shrink-0" do %>
         QuoteCanvas
       <% end %>
 
-      <!-- 中央：PCナビ -->
-      <nav class="hidden lg:flex">
-        <ul class="menu menu-horizontal px-1 items-center">
+      <!-- 中央：PCナビ（縮む担当） -->
+      <nav class="hidden lg:flex flex-1 min-w-0 justify-center">
+        <ul class="menu menu-horizontal px-1 items-center truncate">
           <li><%= link_to "機能", "#{root_path}#features", class: "px-3 h-10 leading-none hover:underline underline-offset-8" %></li>
           <li><%= link_to "使い方", "#{root_path}#how", class: "px-3 h-10 leading-none hover:underline underline-offset-8" %></li>
         </ul>
       </nav>
 
-      <!-- 右：アクション -->
-      <div class="flex items-center gap-2">
+      <!-- 右：アクション（折り返し禁止） -->
+      <div class="flex items-center gap-2 shrink-0">
         <% if user_signed_in? %>
           <div class="dropdown dropdown-end">
             <button class="btn btn-ghost h-10 min-h-10 px-3">
@@ -30,6 +31,7 @@
                 </div>
               </div>
             </button>
+            <!-- ドロップダウンがヘッダー外へ出られるよう overflow は header で隠さない -->
             <ul tabindex="0" class="menu dropdown-content z-[60] p-2 shadow bg-base-100 rounded-box w-56 mt-2">
               <li><%= link_to "プロフィール設定", edit_user_registration_path %></li>
               <li><%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-ghost text-left" %></li>


### PR DESCRIPTION
## 概要
ログイン / ログアウト機能を実装しました。

## 変更内容
- Devise ビューを生成し、ログイン画面を daisyUI で整形
- ヘッダーにログイン状態による表示切り替えを実装
  - 未ログイン時 → 「ログイン」「はじめる」ボタン
  - ログイン時 → ユーザー名 + ドロップダウンメニュー（プロフィール設定、ログアウト）
- ログアウト処理を `button_to method: :delete` で動作確認済み
- Turbo 対応（フラッシュ・リダイレクトでの挙動）

## 関連Issue
Closes #16
