### PR TITLE
ダッシュボードルーティングの追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,14 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
   end
+
+  #  ログイン後の遷移先
+  def after_sign_in_path_for(resource)
+    dashboard_path
+  end
+
+  #  ログアウト後の遷移先
+  def after_sign_out_path_for(resource_or_scope)
+    root_path
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,6 @@
+class DashboardController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+  end
+end

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,0 +1,2 @@
+module DashboardHelper
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-3xl mx-auto mt-20 text-center">
+  <h1 class="text-3xl font-bold mb-4">ダッシュボード</h1>
+  <p class="opacity-70">ここから記録した一節やプロフィールにアクセスできます。</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
+  get "dashboard/index"
   devise_for :users
   get "posts/index"
   get "up" => "rails/health#show", as: :rails_health_check
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  get "dashboard", to: "dashboard#index"
   root "top#index"  # トップページ
 end

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class DashboardControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get dashboard_index_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
ダッシュボードのルーティングを実装しました。

## 変更点
- `DashboardController#index` を作成
- `/dashboard` にルーティングを追加
- ログイン後の遷移先を `/dashboard` に変更
- ログアウト後の遷移先をトップページ (`/`) に変更
- 仮ビュー（ダッシュボードの見出しと説明文）を作成

## 関連Issue
Closes #19 
