### PR TITLE
ダッシュボードページの作成

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,106 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
-@layer components {
-  .btn-primary {
-    @apply py-2 px-4 bg-blue-200;
+/* ---------- Base（フォント） ---------- */
+@layer base {
+  :root {
+    --font-sans: "Inter", "Noto Sans JP", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+    --font-serif: "Shippori Mincho", "Hiragino Mincho ProN", "Hiragino Mincho Pro", YuMincho, "Yu Mincho", Georgia, serif;
   }
+  .font-sans { font-family: var(--font-sans); }
+  .font-serif { font-family: var(--font-serif); }
 }
 
-*/
+/* ---------- Utilities（質感・装飾） ---------- */
+@layer utilities {
+  /* 空のグラデ（上：空色 → 下：生成り） */
+  .gh-sky {
+    background: radial-gradient(80% 60% at 50% 0%, #dff2ff 0%, #f6fbff 60%, #fbf7ef 100%);
+  }
+
+  /* 粒子ノイズ（軽量・画像不要） */
+  .gh-grain {
+    background-image:
+      radial-gradient(circle at 20% 20%, rgba(0,0,0,.04) 0 1px, transparent 1px 100%),
+      radial-gradient(circle at 80% 10%, rgba(0,0,0,.03) 0 1px, transparent 1px 100%);
+    background-size: 10px 10px, 8px 8px;
+    mix-blend-mode: multiply;
+    opacity: .6;
+  }
+
+  /* 生成りの紙 */
+  .gh-paper {
+    background: linear-gradient(#faf7f0, #f5efe2);
+  }
+
+  /* ガラスカード（@apply不使用：エディタ警告回避 & フォールバック） */
+  .gh-glass {
+    /* フォールバック（backdrop-filter非対応環境向け） */
+    background-color: rgba(255,255,255,0.7);
+    border: 1px solid rgba(17,24,39,0.08);
+    box-shadow:
+      0 10px 30px rgba(17,24,39,0.08),
+      inset 0 1px 0 rgba(255,255,255,0.35);
+  }
+  @supports ((-webkit-backdrop-filter: blur(18px)) or (backdrop-filter: blur(18px))) {
+    .gh-glass {
+      -webkit-backdrop-filter: blur(18px);
+      backdrop-filter: blur(18px);
+    }
+  }
+
+  /* 丘のシルエット（CSSのみ） */
+  .gh-hills {
+    --c1: #cfe8d3; --c2: #a9d0b1; --c3: #86b594;
+    background:
+      radial-gradient(60% 40% at 10% 100%, var(--c1) 0 60%, transparent 61%) bottom left/60% 50% no-repeat,
+      radial-gradient(50% 35% at 50% 100%, var(--c2) 0 60%, transparent 61%) bottom center/70% 55% no-repeat,
+      radial-gradient(55% 45% at 90% 100%, var(--c3) 0 60%, transparent 61%) bottom right/60% 50% no-repeat;
+  }
+
+  /* 手描き風の下線 */
+  .gh-underline { position: relative; }
+  .gh-underline::after{
+    content:"";
+    position:absolute; left:0; bottom:-.4rem;
+    height:.3rem; width:6rem;
+    background: linear-gradient(90deg,#d4a373,#ffd082);
+    border-radius: 9999px;
+    opacity:.7;
+    filter: blur(.2px);
+  }
+
+  /* きらめき（控えめアニメ） */
+  .gh-sparkle { position: relative; }
+  .gh-sparkle::after{
+    content:"✦";
+    position:absolute; right:-.8rem; top:-.8rem;
+    font-size:1rem; opacity:.7;
+    animation: sparkle 2.4s ease-in-out infinite;
+  }
+  @keyframes sparkle {
+    0%,100%{ transform: scale(0.8) rotate(0deg); opacity:0; }
+    20%{ transform: scale(1) rotate(12deg); opacity:.9; }
+    60%{ transform: scale(.9) rotate(-8deg); opacity:.5; }
+  }
+
+  /* ふわっと浮く */
+  .hover-float {
+    transition: transform .35s ease, box-shadow .35s ease;
+  }
+  .hover-float:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 10px 24px rgba(0,0,0,.12);
+  }
+
+  /* やさしい風（小さく上下ゆれ） */
+  @keyframes breeze { 0%,100%{ transform: translateY(0) } 50%{ transform: translateY(-3px) } }
+  .breeze { animation: breeze 5s ease-in-out infinite; }
+
+  /* 動きを控えたいユーザー設定に配慮 */
+  @media (prefers-reduced-motion: reduce) {
+    .gh-sparkle::after,
+    .breeze,
+    .hover-float { animation: none !important; transition: none !important; }
+  }
+}

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,5 +2,14 @@ class DashboardController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    # Passageモデル と User#passages の両方があるときだけ触る
+    if defined?(Passage) && current_user.respond_to?(:passages)
+      scope = current_user.passages.order(created_at: :desc)
+      @recent_passages = scope.limit(3)
+      @passages_count  = scope.count
+    else
+      @recent_passages = []
+      @passages_count  = 0
+    end
   end
 end

--- a/app/views/dashboard/_passage_card.html.erb
+++ b/app/views/dashboard/_passage_card.html.erb
@@ -1,0 +1,24 @@
+<% bg = (passage.respond_to?(:bg_color) && passage.bg_color.presence) || "#FAF7F0" %>
+<% fg = (passage.respond_to?(:text_color) && passage.text_color.presence) || "#1F2937" %>
+<% ff = (passage.respond_to?(:font_family) && passage.font_family.presence) || "serif" %>
+
+<div class="relative rounded-2xl p-5 border shadow-sm transition hover-float gh-paper"
+     style="background:<%= bg %>; color:<%= fg %>; font-family:<%= ff %>;">
+  <!-- うっすら粒子 -->
+  <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
+
+  <div class="text-[11px] opacity-70 mb-1 relative">
+    <%= [passage.try(:author), passage.try(:title)].compact_blank.join("『") %><%= passage.try(:title).present? ? "』" : "" %>
+  </div>
+
+  <div class="text-base md:text-lg font-semibold leading-relaxed line-clamp-4 relative">
+    <%= passage.try(:body) || "（本文）" %>
+  </div>
+
+  <div class="mt-3 flex items-center justify-between text-xs opacity-70 relative">
+    <span><%= passage.created_at&.in_time_zone&.strftime("%Y-%m-%d") %></span>
+    <% if defined?(passage_path) && passage.respond_to?(:id) %>
+      <%= link_to "詳細", passage_path(passage), class: "link link-hover" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,104 @@
-<div class="max-w-3xl mx-auto mt-20 text-center">
-  <h1 class="text-3xl font-bold mb-4">ダッシュボード</h1>
-  <p class="opacity-70">ここから記録した一節やプロフィールにアクセスできます。</p>
+<!-- 背景：空＋丘＋粒子 -->
+<div class="fixed inset-0 -z-10 gh-sky">
+  <div class="absolute inset-0 gh-hills opacity-70"></div>
+  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
+</div>
+
+<div class="container mx-auto max-w-7xl px-4 md:px-8">
+  <!-- Hero：やわらかい歓迎とクイックアクション -->
+  <section class="mt-2 md:mt-4">
+    <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden hover-float">
+      <!-- 光のにじみ -->
+      <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
+
+      <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 relative">
+        <div>
+          <h1 class="text-2xl md:text-3xl font-extrabold gh-underline gh-sparkle">
+            こんにちは、<%= current_user.name.presence || "読者" %> さん
+          </h1>
+          <p class="mt-2 opacity-80">
+            風のようにすっと書き留めて、森の本棚にそっと並べよう。
+          </p>
+        </div>
+        <div class="flex flex-wrap gap-2 shrink-0">
+          <%= link_to (defined?(new_passage_path) ? new_passage_path : "#"), class: "btn btn-primary breeze" do %>
+            ＋ 一節を記録
+          <% end %>
+          <%= link_to (defined?(passages_path) ? passages_path : "#"), class: "btn btn-outline hover-float" do %>
+            一覧を見る
+          <% end %>
+          <%= link_to edit_user_registration_path, class: "btn btn-ghost hover-float" do %>
+            プロフィール
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- サマリ：小さな“本のカード” -->
+  <section class="mt-6 grid gap-4 sm:grid-cols-3">
+    <div class="rounded-2xl gh-glass p-5 relative hover-float">
+      <div class="text-sm opacity-70">あなたのカード</div>
+      <div class="text-3xl font-extrabold mt-1"><%= @passages_count %></div>
+    </div>
+    <a href="<%= root_path %>#features" class="rounded-2xl gh-glass p-5 hover-float">
+      <div class="text-sm opacity-70">カスタマイズ</div>
+      <div class="mt-1">色・フォントで“言葉の表情”を変える</div>
+    </a>
+    <%= link_to edit_user_registration_path, class: "rounded-2xl gh-glass p-5 hover-float" do %>
+      <div class="text-sm opacity-70">プロフィール</div>
+      <div class="mt-1 truncate"><%= current_user.email %></div>
+    <% end %>
+  </section>
+
+  <!-- 最近の一節：カード棚（3列） -->
+  <section class="mt-10">
+    <div class="flex items-end justify-between">
+      <div>
+        <h2 class="text-xl md:text-2xl font-bold gh-underline">最近の記録</h2>
+        <p class="opacity-70 text-sm mt-1">直近3枚のカードをピックアップ</p>
+      </div>
+      <%= link_to (defined?(passages_path) ? passages_path : "#"), class: "link link-primary" do %>
+        すべて見る →
+      <% end %>
+    </div>
+
+    <% if @recent_passages.any? %>
+      <div class="mt-5 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        <% @recent_passages.each do |p| %>
+          <%= render "dashboard/passage_card", passage: p %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="mt-6 rounded-3xl gh-glass p-10 text-center hover-float">
+        <div class="text-4xl mb-2">🌿</div>
+        <p class="font-semibold">まだカードがありません</p>
+        <p class="opacity-70 text-sm mt-1">心に残った一文を、最初の1枚に。</p>
+        <div class="mt-4">
+          <%= link_to (defined?(new_passage_path) ? new_passage_path : "#"), class: "btn btn-primary breeze" do %>
+            ＋ 一節を記録
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </section>
+
+  <!-- ショートガイド：森の黒板っぽく -->
+  <section class="mt-10 grid gap-4 md:grid-cols-3">
+    <div class="rounded-2xl gh-glass p-6 hover-float">
+      <div class="text-2xl">✍️</div>
+      <div class="font-bold mt-2">書き留める</div>
+      <p class="opacity-75 text-sm mt-1">本文・著者・タイトルをサッと入力</p>
+    </div>
+    <div class="rounded-2xl gh-glass p-6 hover-float">
+      <div class="text-2xl">🎨</div>
+      <div class="font-bold mt-2">彩る</div>
+      <p class="opacity-75 text-sm mt-1">背景・文字色・フォントで個性を</p>
+    </div>
+    <div class="rounded-2xl gh-glass p-6 hover-float">
+      <div class="text-2xl">🗂️</div>
+      <div class="font-bold mt-2">並べる</div>
+      <p class="opacity-75 text-sm mt-1">あとで眺めて、また好きになる</p>
+    </div>
+  </section>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,58 +1,35 @@
-<div class="min-h-dvh flex items-center bg-base-200">
-  <div class="container max-w-lg mx-auto px-4">
-    <div class="card bg-base-100 shadow-xl">
-      <div class="card-body">
-        <h1 class="card-title text-2xl">新規登録</h1>
+<%= render "shared/auth_container" do %>
+  <h1 class="text-2xl md:text-3xl font-serif tracking-tight text-center gh-underline">
+    無料ではじめる
+  </h1>
+  <p class="text-center opacity-70 font-sans mt-1">1分で登録。いつでも削除できます。</p>
 
-        <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-          <% if resource.errors.any? %>
-            <div class="alert alert-error">
-              <span>入力内容を確認してください</span>
-              <ul class="mt-2 text-sm list-disc ml-6">
-                <% resource.errors.full_messages.each do |msg| %>
-                  <li><%= msg %></li>
-                <% end %>
-              </ul>
-            </div>
-          <% end %>
-
-          <%# 追加フィールド name（任意） %>
-          <div class="form-control">
-            <label class="label" for="user_name">
-              <span class="label-text">表示名（任意）</span>
-            </label>
-            <%= f.text_field :name, autofocus: true, class: "input input-bordered w-full", placeholder: "例）コウキ" %>
-          </div>
-
-          <div class="form-control mt-3">
-            <label class="label" for="user_email">
-              <span class="label-text">メールアドレス</span>
-            </label>
-            <%= f.email_field :email, class: "input input-bordered w-full", autocomplete: "email", required: true %>
-          </div>
-
-          <div class="form-control mt-3">
-            <label class="label" for="user_password">
-              <span class="label-text">パスワード <span class="opacity-60 text-xs">(6文字以上)</span></span>
-            </label>
-            <%= f.password_field :password, class: "input input-bordered w-full", autocomplete: "new-password", required: true %>
-          </div>
-
-          <div class="form-control mt-3">
-            <label class="label" for="user_password_confirmation">
-              <span class="label-text">パスワード（確認）</span>
-            </label>
-            <%= f.password_field :password_confirmation, class: "input input-bordered w-full", autocomplete: "new-password", required: true %>
-          </div>
-
-          <div class="form-control mt-6">
-            <%= f.submit "登録する", class: "btn btn-primary w-full" %>
-          </div>
-        <% end %>
-
-        <div class="divider">または</div>
-        <%= render "devise/shared/links" %>
-      </div>
+  <%= form_with model: resource, url: registration_path(resource_name), class: "mt-6 space-y-4 font-sans" do |f| %>
+    <div>
+      <%= f.label :name, "表示名", class: "label" %>
+      <%= f.text_field :name, class: "input input-bordered w-full", placeholder: "コウキ" %>
     </div>
+
+    <div>
+      <%= f.label :email, class: "label" %>
+      <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full", placeholder: "you@example.com" %>
+    </div>
+
+    <div>
+      <%= f.label :password, class: "label" %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full" %>
+      <p class="text-xs opacity-60 mt-1">6文字以上</p>
+    </div>
+
+    <div>
+      <%= f.label :password_confirmation, class: "label" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered w-full" %>
+    </div>
+
+    <%= f.submit "アカウントを作成", class: "btn btn-primary w-full btn-press" %>
+  <% end %>
+
+  <div class="text-center mt-4">
+    <%= link_to "すでにアカウントをお持ちの方はこちら", new_user_session_path, class: "link link-primary underline-grow" %>
   </div>
-</div>
+<% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,30 +1,33 @@
-<div class="max-w-md mx-auto mt-20 card bg-base-100 shadow-xl">
-  <div class="card-body">
-    <h2 class="text-2xl font-bold text-center mb-4">ログイン</h2>
+<%= render "shared/auth_container" do %>
+  <h1 class="text-2xl md:text-3xl font-serif tracking-tight text-center gh-underline">
+    ログイン
+  </h1>
 
-    <%= form_with model: resource, url: session_path(resource_name), class: "space-y-4" do |f| %>
-      <div>
-        <%= f.label :email, class: "label" %>
-        <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full" %>
-      </div>
-
-      <div>
-        <%= f.label :password, class: "label" %>
-        <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered w-full" %>
-      </div>
-
-      <div class="flex justify-between items-center">
-        <%= f.check_box :remember_me, class: "checkbox" %>
-        <%= f.label :remember_me, "ログイン状態を保持" %>
-      </div>
-
-      <div>
-        <%= f.submit "ログイン", class: "btn btn-primary w-full" %>
-      </div>
-    <% end %>
-
-    <div class="text-center mt-4">
-      <%= link_to "新規登録はこちら", new_user_registration_path, class: "link link-primary" %>
+  <%= form_with model: resource, url: session_path(resource_name), class: "mt-6 space-y-4 font-sans" do |f| %>
+    <div>
+      <%= f.label :email, class: "label" %>
+      <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full" %>
     </div>
+
+    <div>
+      <%= f.label :password, class: "label" %>
+      <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="flex items-center justify-between text-sm">
+      <% if devise_mapping.rememberable? %>
+        <label class="label cursor-pointer gap-2">
+          <%= f.check_box :remember_me, class: "checkbox" %>
+          <span class="label-text">ログイン状態を保持</span>
+        </label>
+      <% end %>
+      <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "link link-primary" if devise_mapping.recoverable? %>
+    </div>
+
+    <%= f.submit "ログイン", class: "btn btn-primary w-full btn-press" %>
+  <% end %>
+
+  <div class="text-center mt-4">
+    <%= link_to "新規登録はこちら", new_user_registration_path, class: "link link-primary underline-grow" %>
   </div>
-</div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Shippori+Mincho:wght@600;700&display=swap" rel="stylesheet">
   </head>
 
   <body class="min-h-dvh flex flex-col bg-base-200">

--- a/app/views/shared/_auth_container.html.erb
+++ b/app/views/shared/_auth_container.html.erb
@@ -1,0 +1,11 @@
+<!-- 背景：空＋丘＋粒子（authページ専用） -->
+<div class="fixed inset-0 -z-10 gh-sky">
+  <div class="absolute inset-0 gh-hills opacity-70"></div>
+  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
+</div>
+
+<div class="min-h-[70vh] flex items-center justify-center px-4">
+  <div class="w-full max-w-md rounded-3xl gh-glass p-7 md:p-9 elev-2">
+    <%= yield %>
+  </div>
+</div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,168 +1,161 @@
-<!-- 背景のデコ（グラデ＋ぼかし） -->
-<div class="pointer-events-none fixed inset-0 -z-10">
-  <div class="absolute -top-24 -left-24 size-72 rounded-full bg-gradient-to-tr from-primary/25 to-secondary/25 blur-3xl"></div>
-  <div class="absolute -bottom-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-accent/20 to-primary/25 blur-3xl"></div>
+<!-- 背景：空＋丘＋粒子 -->
+<div class="fixed inset-0 -z-10 gh-sky">
+  <div class="absolute inset-0 gh-hills opacity-70"></div>
+  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
 </div>
 
 <section class="pt-10 md:pt-12">
-  <!-- Hero -->
   <div class="container mx-auto max-w-7xl px-4 md:px-8">
-    <div class="grid items-center gap-10 lg:grid-cols-2">
-      <div class="max-w-xl mx-auto">
-        <span class="badge badge-primary mb-3">MVP</span>
-        <h1 class="text-4xl md:text-5xl font-extrabold leading-tight">
-          一節が、<span class="bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">記憶</span>になる。
-        </h1>
-        <p class="mt-4 text-base md:text-lg opacity-80">
-          読書や日常で心に刺さった一節を、<b>著者・タイトル付き</b>で保存。背景色やフォントを<b>自分好みにカスタム</b>して、カードとしてコレクション。
-        </p>
 
-        <div class="mt-8 flex flex-col sm:flex-row gap-3">
-          <%= link_to "無料ではじめる", new_user_registration_path, class: "btn btn-primary btn-lg" %>
-          <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-lg" %>
+    <!-- Hero -->
+    <div class="rounded-3xl gh-glass p-8 md:p-10 relative overflow-hidden hover-float">
+      <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
+
+      <div class="grid items-center gap-10 lg:grid-cols-2">
+        <div>
+          <span class="badge badge-primary mb-3">MVP</span>
+          <h1 class="font-serif text-4xl md:text-5xl tracking-tight gh-underline gh-sparkle">
+            一節が、記憶になる。
+          </h1>
+          <p class="mt-4 text-base md:text-lg opacity-85 font-sans">
+            読書や日常で心に刺さった一節を、<b>著者・タイトル</b>と一緒に保存。<br>
+            背景・文字色・フォントを<b>自分らしくカスタム</b>して、“紙カード”としてコレクション。
+          </p>
+
+          <div class="mt-8 flex flex-col sm:flex-row gap-3">
+            <%= link_to "無料ではじめる", new_user_registration_path, class: "btn btn-primary btn-press" %>
+            <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-press underline-grow" %>
+          </div>
+          <p class="mt-3 text-xs opacity-60 font-sans">登録は1分。いつでも削除できます。</p>
         </div>
 
-        <p class="mt-3 text-xs opacity-60">登録は1分。いつでも削除できます。</p>
-      </div>
-
-      <!-- プレビューカード（ガラス風） -->
-      <div class="max-w-lg mx-auto w-full">
-        <div class="rounded-3xl bg-base-100/70 backdrop-blur-xl border shadow-xl">
-          <div class="p-6 md:p-8 space-y-6">
-            <h2 class="font-bold text-xl">カード表示プレビュー</h2>
-
-            <!-- 大カード -->
-            <div class="rounded-2xl p-6 border shadow-sm"
-                 style="background:#FFF5D6; color:#1F2937; font-family: serif;">
-              <div class="text-xs opacity-70 mb-1">夏目 漱石『こころ』</div>
-              <div class="text-xl md:text-2xl font-semibold leading-relaxed">
-                「人間は弱いものだ。弱い自分を知ることから始まる。」
+        <!-- プレビュー（紙カード風） -->
+        <div class="max-w-lg mx-auto w-full">
+          <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden elev-2">
+            <div class="grid gap-5">
+              <div class="relative rounded-2xl p-6 border gh-paper card-lift">
+                <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
+                <div class="text-[11px] opacity-70 mb-1 font-sans">夏目 漱石『こころ』</div>
+                <div class="text-xl md:text-2xl font-semibold leading-relaxed font-serif">
+                  「人は弱い。弱さを知るところから、やさしさが始まる。」
+                </div>
               </div>
+
+              <div class="grid grid-cols-2 gap-4">
+                <div class="relative rounded-2xl p-4 border card-lift" style="background:#111827; color:#F9FAFB; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">
+                  <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl opacity-40"></div>
+                  <div class="text-[10px] opacity-70 mb-1">Unknown『Daily Notes』</div>
+                  <div class="text-sm font-semibold">Keep the words that keep you.</div>
+                </div>
+                <div class="relative rounded-2xl p-4 border gh-paper card-lift" style="color:#065F46; font-family: var(--font-sans);">
+                  <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
+                  <div class="text-[10px] opacity-70 mb-1">川端 康成『雪国』</div>
+                  <div class="text-sm font-semibold">国境の長いトンネルを抜けると雪国であった。</div>
+                </div>
+              </div>
+
+              <p class="text-xs opacity-60 font-sans">* カードは記録内容に合わせて美しくレイアウトされます</p>
             </div>
-
-            <!-- 小カード2枚 -->
-            <div class="grid grid-cols-2 gap-4">
-              <div class="rounded-xl p-4 border shadow-sm transition-transform duration-300 hover:-translate-y-1"
-                   style="background:#111827; color:#F9FAFB; font-family: monospace;">
-                <div class="text-[10px] opacity-70 mb-1">Unknown『Daily Notes』</div>
-                <div class="text-sm font-semibold">Keep the words that keep you.</div>
-              </div>
-              <div class="rounded-xl p-4 border shadow-sm transition-transform duration-300 hover:-translate-y-1"
-                   style="background:#ECFDF5; color:#065F46; font-family: sans-serif;">
-                <div class="text-[10px] opacity-70 mb-1">川端 康成『雪国』</div>
-                <div class="text-sm font-semibold">国境の長いトンネルを抜けると雪国であった。</div>
-              </div>
-            </div>
-
-            <p class="text-xs opacity-60">* カードは記録内容に合わせて美しくレイアウトされます</p>
           </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
 
-<!-- Features : グラスカード -->
-<section id="features" class="py-20">
-  <div class="container mx-auto max-w-7xl px-4 md:px-8">
-    <h2 class="text-3xl md:text-4xl font-bold text-center">QuoteCanvas の特徴</h2>
-    <p class="text-center opacity-70 mt-2">“使う理由”がひと目でわかる3つ</p>
+    <!-- Features -->
+    <section id="features" class="scroll-mt-24 py-16">
+      <h2 class="text-3xl md:text-4xl font-bold text-center font-serif gh-underline">QuoteCanvas の特徴</h2>
+      <p class="text-center opacity-70 mt-2 font-sans">“使う理由”がひと目でわかる3つ</p>
 
-    <div class="mt-10 grid gap-6 md:grid-cols-3">
-      <%[
-        {icon:"📌", title:"秒速で記録",  body:"本文・著者・タイトルをサクッと保存。忘れないうちに。"},
-        {icon:"🎨", title:"自由にカスタム", body:"背景色・文字色・フォントを好みに。作る楽しさも味わえる。"},
-        {icon:"🗂️", title:"あとで味わう",  body:"カードとしてコレクション化。見返す時間が豊かになる。"}
-      ].each do |f| %>
-        <div class="rounded-2xl bg-base-100/60 backdrop-blur border shadow-sm p-6 transition duration-300 hover:shadow-lg">
-          <div class="text-3xl"><%= f[:icon] %></div>
-          <h3 class="mt-3 font-bold text-xl"><%= f[:title] %></h3>
-          <p class="opacity-80 mt-2 text-sm"><%= f[:body] %></p>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</section>
-
-<!-- Showcase : ギャラリー -->
-<section class="py-20 bg-base-200">
-  <div class="container mx-auto max-w-7xl px-4 md:px-8">
-    <h2 class="text-3xl md:text-4xl font-bold text-center">カード・ギャラリー</h2>
-    <p class="text-center opacity-70 mt-2">色とフォントで“言葉の表情”が変わる</p>
-
-    <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      <% samples = [
-        {bg:"#FDF2F8", fg:"#4A044E", font:"serif",    meta:"与謝野晶子『みだれ髪』", body:"その手をば柔らかにして我に触れよ"},
-        {bg:"#111827", fg:"#F9FAFB", font:"monospace",meta:"Unknown『Daily Notes』", body:"Write what you don't want to forget."},
-        {bg:"#ECFDF5", fg:"#065F46", font:"sans-serif",meta:"川端 康成『雪国』", body:"国境の長いトンネルを抜けると雪国であった。"},
-        {bg:"#FEF3C7", fg:"#78350F", font:"serif",    meta:"夏目 漱石『草枕』", body:"智に働けば角が立つ。情に棹させば流される。"},
-        {bg:"#DBEAFE", fg:"#1E3A8A", font:"sans-serif",meta:"吉本ばなな『キッチン』", body:"この世で一番好きな場所は台所だ。"},
-        {bg:"#F3F4F6", fg:"#111827", font:"monospace",meta:"Unknown『Work Log』", body:"Small, steady steps compound."}
-      ] %>
-      <% samples.each do |c| %>
-        <div class="rounded-2xl p-6 border shadow-sm hover:shadow-lg transition"
-             style="background:<%= c[:bg] %>; color:<%= c[:fg] %>; font-family:<%= c[:font] %>;">
-          <div class="text-[11px] opacity-70 mb-1"><%= c[:meta] %></div>
-          <div class="text-lg font-semibold leading-relaxed"><%= c[:body] %></div>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</section>
-
-<!-- Use cases : 使いどころ -->
-<section id="how" class="py-20">
-  <div class="container mx-auto max-w-7xl px-4 md:px-8">
-    <h2 class="text-3xl md:text-4xl font-bold text-center">どんなときに？</h2>
-    <p class="text-center opacity-70 mt-2">あなたの毎日に“言葉の居場所”を</p>
-
-    <div class="mt-10 grid gap-6 md:grid-cols-3">
-      <%[
-        {emoji:"📚", title:"読書ノートに", body:"心に残った一文をその場で保存。後でまとめて味わう。"},
-        {emoji:"🧠", title:"学習メモに",  body:"講義や記事のフレーズを抜き出して、知識の核に。"},
-        {emoji:"🌤", title:"日々の気づきに", body:"生活の中の言葉をカード化。いつでも見返せる宝箱。"}
-      ].each do |u| %>
-        <div class="rounded-2xl bg-base-100/70 backdrop-blur p-6 border shadow-sm">
-          <div class="text-3xl"><%= u[:emoji] %></div>
-          <h3 class="mt-3 font-bold text-xl"><%= u[:title] %></h3>
-          <p class="opacity-80 mt-2 text-sm"><%= u[:body] %></p>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</section>
-
-<!-- Future : ロードマップ（期待感） -->
-<section class="py-20 bg-base-200">
-  <div class="container mx-auto max-w-7xl px-4 md:px-8">
-    <h2 class="text-3xl md:text-4xl font-bold text-center">これから</h2>
-    <p class="text-center opacity-70 mt-2">MVP後に予定しているアップデート</p>
-
-    <div class="mt-10 grid gap-6 md:grid-cols-3">
-      <%[
-        {title:"思考ログ", body:"記録した一節にメモや気づきを添えて、後で思考を辿れるように。"},
-        {title:"書籍API連携", body:"著者名・タイトル補完や書影取得で、入力と見栄えをスムーズに。"},
-        {title:"カード共有", body:"作ったカードを画像として共有。SNSやブログに貼り付けやすく。"}
-      ].each do |f| %>
-        <div class="rounded-2xl p-6 border shadow-sm bg-base-100/80">
-          <h3 class="font-bold text-xl"><%= f[:title] %></h3>
-          <p class="opacity-80 mt-2 text-sm"><%= f[:body] %></p>
-        </div>
-      <% end %>
-    </div>
-  </div>
-</section>
-
-<!-- CTA（締め） -->
-<section class="py-20">
-  <div class="container mx-auto max-w-4xl px-4 text-center">
-    <div class="rounded-3xl bg-gradient-to-r from-primary to-secondary text-primary-content p-10 shadow-xl">
-      <h2 class="text-3xl md:text-4xl font-extrabold">さぁ、一節をカードにしよう。</h2>
-      <p class="mt-2 opacity-90">言葉を集める。自分の色で、記憶にする。</p>
-      <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
-        <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-secondary btn-lg" %>
-        <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost btn-lg" %>
+      <div class="mt-10 grid gap-6 md:grid-cols-3">
+        <%[
+          {icon:"📌", title:"秒速で記録",  body:"本文・著者・タイトルをサクッと保存。忘れないうちに。"},
+          {icon:"🎨", title:"自由にカスタム", body:"背景色・文字色・フォントを好みに。作る楽しさも。"},
+          {icon:"🗂️", title:"あとで味わう",  body:"カードとしてコレクション。見返す時間が豊かに。"}
+        ].each do |f| %>
+          <div class="rounded-2xl gh-glass p-6 hover-float">
+            <div class="text-3xl"><%= f[:icon] %></div>
+            <h3 class="mt-3 font-bold text-xl font-sans"><%= f[:title] %></h3>
+            <p class="opacity-80 mt-2 text-sm font-sans"><%= f[:body] %></p>
+          </div>
+        <% end %>
       </div>
-    </div>
+    </section>
+
+    <!-- Gallery -->
+    <section class="py-16">
+      <h2 class="text-3xl md:text-4xl font-bold text-center font-serif gh-underline">カード・ギャラリー</h2>
+      <p class="text-center opacity-70 mt-2 font-sans">色とフォントで“言葉の表情”が変わる</p>
+
+      <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <% samples = [
+          {bg:"#FDF2F8", fg:"#4A044E", font:"var(--font-serif)",    meta:"与謝野晶子『みだれ髪』", body:"その手をば柔らかにして我に触れよ"},
+          {bg:"#111827", fg:"#F9FAFB", font:"ui-monospace,SFMono-Regular,Menlo,monospace", meta:"Unknown『Daily Notes』", body:"Write what you don't want to forget."},
+          {bg:"#ECFDF5", fg:"#065F46", font:"var(--font-sans)",      meta:"川端 康成『雪国』", body:"国境の長いトンネルを抜けると雪国であった。"},
+          {bg:"#FEF3C7", fg:"#78350F", font:"var(--font-serif)",    meta:"夏目 漱石『草枕』", body:"智に働けば角が立つ。情に棹させば流される。"},
+          {bg:"#DBEAFE", fg:"#1E3A8A", font:"var(--font-sans)",      meta:"吉本ばなな『キッチン』", body:"この世で一番好きな場所は台所だ。"},
+          {bg:"#F3F4F6", fg:"#111827", font:"ui-monospace,SFMono-Regular,Menlo,monospace", meta:"Unknown『Work Log』", body:"Small, steady steps compound."}
+        ] %>
+        <% samples.each do |c| %>
+          <div class="relative rounded-2xl p-6 border card-lift"
+               style="background:<%= c[:bg] %>; color:<%= c[:fg] %>; font-family:<%= c[:font] %>;">
+            <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
+            <div class="text-[11px] opacity-70 mb-1 font-sans"><%= c[:meta] %></div>
+            <div class="text-lg font-semibold leading-relaxed"><%= c[:body] %></div>
+          </div>
+        <% end %>
+      </div>
+    </section>
+
+    <!-- How / Use cases -->
+    <section id="how" class="scroll-mt-24 py-16">
+      <h2 class="text-3xl md:text-4xl font-bold text-center font-serif gh-underline">どんなときに？</h2>
+      <p class="text-center opacity-70 mt-2 font-sans">あなたの毎日に“言葉の居場所”を</p>
+
+      <div class="mt-10 grid gap-6 md:grid-cols-3">
+        <%[
+          {emoji:"📚", title:"読書ノートに", body:"心に残った一文をその場で保存。後でまとめて味わう。"},
+          {emoji:"🧠", title:"学習メモに",  body:"講義や記事のフレーズを抜き出して、知識の核に。"},
+          {emoji:"🌤", title:"日々の気づきに", body:"生活の中の言葉をカード化。いつでも見返せる宝箱。"}
+        ].each do |u| %>
+          <div class="rounded-2xl gh-glass p-6 hover-float">
+            <div class="text-3xl"><%= u[:emoji] %></div>
+            <h3 class="mt-3 font-bold text-xl font-sans"><%= u[:title] %></h3>
+            <p class="opacity-80 mt-2 text-sm font-sans"><%= u[:body] %></p>
+          </div>
+        <% end %>
+      </div>
+    </section>
+
+    <!-- Roadmap -->
+    <section class="py-16">
+      <h2 class="text-3xl md:text-4xl font-bold text-center font-serif gh-underline">これから</h2>
+      <p class="text-center opacity-70 mt-2 font-sans">MVP後に予定しているアップデート</p>
+
+      <div class="mt-10 grid gap-6 md:grid-cols-3">
+        <%[
+          {title:"思考ログ", body:"記録した一節にメモや気づきを添えて、後で思考を辿れるように。"},
+          {title:"書籍API連携", body:"著者名・タイトル補完や書影取得で、入力と見栄えをスムーズに。"},
+          {title:"カード共有", body:"作ったカードを画像として共有。SNSやブログに貼り付けやすく。"}
+        ].each do |f| %>
+          <div class="rounded-2xl gh-glass p-6 hover-float">
+            <h3 class="font-bold text-xl font-sans"><%= f[:title] %></h3>
+            <p class="opacity-80 mt-2 text-sm font-sans"><%= f[:body] %></p>
+          </div>
+        <% end %>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-16">
+      <div class="rounded-3xl bg-gradient-to-r from-primary to-secondary text-primary-content p-10 text-center shadow-xl hover-float">
+        <h2 class="font-serif text-3xl md:text-4xl font-extrabold tracking-tight">さぁ、一節をカードにしよう。</h2>
+        <p class="mt-2 opacity-90 font-sans">言葉を集める。自分の色で、記憶にする。</p>
+        <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
+          <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-secondary btn-press" %>
+          <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost btn-press underline-grow" %>
+        </div>
+      </div>
+    </section>
+
   </div>
 </section>


### PR DESCRIPTION
## 概要
- 新規登録 / ログイン画面のレイアウトを修正し、アプリ全体のデザインコンセプトに統一しました
- 共通パーシャル (`shared/_auth_container.html.erb`) を作成し、背景・カード枠を共通化

## 変更内容
- [x] `app/views/shared/_auth_container.html.erb` を追加
- [x] devise/sessions#new, devise/registrations#new をデザイン更新
- [x] トップページ/ダッシュボードと同じ「空・丘・ガラス」の質感に統一
- [x] 入力フォームをカード中央寄せ、見出しを明朝体、本文はサンセリフ体に調整

## 確認方法
1. `/users/sign_up` にアクセス → 「無料ではじめる」フォームが表示されること
2. `/users/sign_in` にアクセス → ログインフォームが中央寄せで表示されること
3. ヘッダー固定と被らず、背景が `gh-sky + gh-hills` で表示されることを確認

## 関連Issue
- close #20