### PR TITLE
passagesモデルの作成

### DIFF
--- a/app/models/passage.rb
+++ b/app/models/passage.rb
@@ -1,2 +1,8 @@
 class Passage < ApplicationRecord
+  belongs_to :user, optional: true  # 既存データを壊さないため一旦 optional。後で必須化OK
+
+  validates :body, presence: true, length: { maximum: 2000 }
+  validates :title, length: { maximum: 200 }, allow_blank: true
+  validates :author, length: { maximum: 120 }, allow_blank: true
+  validates :bg_color, :text_color, :font_family, length: { maximum: 50 }, allow_blank: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,5 @@ class User < ApplicationRecord
   validates :name, length: { maximum: 30 }, allow_blank: true
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :passages, dependent: :destroy
 end

--- a/db/migrate/20250826021235_adjust_passages_for_mvp.rb
+++ b/db/migrate/20250826021235_adjust_passages_for_mvp.rb
@@ -1,0 +1,18 @@
+class AdjustPassagesForMvp < ActiveRecord::Migration[7.2]
+  def change
+    change_table :passages, bulk: true do |t|
+      # 既存の列名をアプリ側の想定に合わせてリネーム
+      t.rename :content, :body
+      t.rename :author_name, :author
+
+      # 追加（任意入力OKの見た目カスタム用）
+      t.string :title
+      t.string :bg_color
+      t.string :text_color
+      t.string :font_family
+
+      # ユーザー紐付け（既存データを壊さないため一旦 null: true）
+      t.references :user, foreign_key: true, index: true, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_23_062254) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_26_021235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "passages", force: :cascade do |t|
-    t.text "content"
-    t.string "author_name"
+    t.text "body"
+    t.string "author"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "bg_color"
+    t.string "text_color"
+    t.string "font_family"
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_passages_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -38,4 +44,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_23_062254) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "passages", "users"
 end

--- a/test/fixtures/passages.yml
+++ b/test/fixtures/passages.yml
@@ -1,9 +1,15 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
-  content: MyText
-  author_name: MyString
+  body: "テストの一節A"
+  title: "タイトルA"
+  author: "著者A"
+  bg_color: "#FAF7F0"
+  text_color: "#111827"
+  font_family: "serif"
 
 two:
-  content: MyText
-  author_name: MyString
+  body: "テストの一節B"
+  title: "タイトルB"
+  author: "著者B"
+  bg_color: "#ECFDF5"
+  text_color: "#065F46"
+  font_family: "var(--font-sans)"


### PR DESCRIPTION
## 概要
- PassageモデルをMVP仕様に合わせて整備しました
- content / author_name を body / author にリネーム
- title, bg_color, text_color, font_family カラムを追加
- Userとの関連付けを設定

## 変更点
- db/migrate: passagesテーブルのリネーム＆カラム追加
- app/models/passage.rb: アソシエーション & バリデーション追加
- app/models/user.rb: has_many :passages を追加
- test/fixtures/passages.yml: カラム名をbody/authorに変更

## 確認方法
1. `bin/rails db:migrate` が正常に完了すること
2. `rails c` で `User.last.passages.create!(body: "テスト")` が成功すること
3. ダッシュボードに最近のPassageが表示されること
4. CIテストがグリーンになること

## 関連Issue
close #21