### PR TITLE
詳細ページ作成

### DIFF
--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -1,20 +1,33 @@
 class PassagesController < ApplicationController
+  before_action :authenticate_user!, except: [ :show ]
+  before_action :set_passage, only: [ :show ]
+
   def new
-    @passage = Passage.new
+    @passage = current_user.passages.build
   end
 
   def create
-  @passage = current_user.passages.build(passage_params)
-  if @passage.save
-    redirect_to dashboard_path, notice: "一節を保存しました！"
-  else
-    render :new, status: :unprocessable_entity
+    @passage = current_user.passages.build(passage_params)
+    if @passage.save
+      redirect_to dashboard_path, notice: "一節を保存しました！"
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
-end
+
+  def show
+    # 公開/非公開の概念がなければそのまま表示
+    # 自分のものだけ見せたいなら以下のような制約を後で入れる
+    # redirect_to root_path, alert: "権限がありません" unless @passage.user_id == current_user&.id
+  end
 
   private
 
+  def set_passage
+    @passage = Passage.find(params[:id])
+  end
+
   def passage_params
-    params.require(:passage).permit(:content)
+    params.require(:passage).permit(:content, :title, :author, :bg_color, :text_color, :font_family)
   end
 end

--- a/app/views/dashboard/_passage_card.html.erb
+++ b/app/views/dashboard/_passage_card.html.erb
@@ -2,8 +2,10 @@
 <% fg = (passage.respond_to?(:text_color) && passage.text_color.presence) || "#1F2937" %>
 <% ff = (passage.respond_to?(:font_family) && passage.font_family.presence) || "serif" %>
 
-<div class="relative rounded-2xl p-5 border shadow-sm transition hover-float gh-paper"
-     style="background:<%= bg %>; color:<%= fg %>; font-family:<%= ff %>;">
+<%= link_to passage_path(passage),
+            class: "block relative rounded-2xl p-5 border shadow-sm transition hover-float gh-paper",
+            style: "background:#{bg}; color:#{fg}; font-family:#{ff};" do %>
+
   <!-- うっすら粒子 -->
   <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
 
@@ -12,13 +14,11 @@
   </div>
 
   <div class="text-base md:text-lg font-semibold leading-relaxed line-clamp-4 relative">
-    <%= passage.try(:body) || "（本文）" %>
+    <%= passage.try(:content) || "（本文）" %>
   </div>
 
   <div class="mt-3 flex items-center justify-between text-xs opacity-70 relative">
     <span><%= passage.created_at&.in_time_zone&.strftime("%Y-%m-%d") %></span>
-    <% if defined?(passage_path) && passage.respond_to?(:id) %>
-      <%= link_to "詳細", passage_path(passage), class: "link link-hover" %>
-    <% end %>
+    <span class="link link-hover">詳細 →</span>
   </div>
-</div>
+<% end %>

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -1,0 +1,67 @@
+<!-- 背景：空＋丘＋粒子（トップ同様） -->
+<div class="fixed inset-0 -z-10 gh-sky">
+  <div class="absolute inset-0 gh-hills opacity-70"></div>
+  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
+</div>
+
+<div class="container mx-auto max-w-7xl px-4 md:px-8 py-8 md:py-12">
+  <div class="mb-6">
+    <%= link_to "← 戻る", (request.referer || root_path), class: "link link-primary" %>
+  </div>
+
+  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden">
+    <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
+
+    <div class="grid gap-6 md:grid-cols-2 items-start">
+      <!-- カード本体 -->
+      <div class="relative rounded-2xl p-6 border card-lift"
+           style="background:<%= @passage.bg_color.presence || '#F9FAFB' %>;
+                  color:<%= @passage.text_color.presence || '#111827' %>;
+                  font-family:<%= @passage.font_family.presence || 'var(--font-serif)' %>;">
+        <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
+
+        <% if @passage.title.present? || @passage.author.present? %>
+          <div class="text-[11px] opacity-70 mb-1 font-sans">
+            <%= [@passage.author, @passage.title.presence&.yield_self { |t| "『#{t}』" }].compact.join(" ") %>
+          </div>
+        <% end %>
+
+        <div class="text-lg md:text-2xl font-semibold leading-relaxed">
+          <%= simple_format(h(@passage.content)) %>
+        </div>
+      </div>
+
+      <!-- メタ情報 -->
+      <div class="space-y-4">
+        <h1 class="text-2xl md:text-3xl font-bold gh-underline">一節の詳細</h1>
+
+        <div class="rounded-2xl gh-glass p-5">
+          <dl class="grid grid-cols-3 gap-3 text-sm">
+            <dt class="opacity-70">著者</dt>
+            <dd class="col-span-2"><%= @passage.author.presence || "-" %></dd>
+
+            <dt class="opacity-70">タイトル</dt>
+            <dd class="col-span-2"><%= @passage.title.presence || "-" %></dd>
+
+            <dt class="opacity-70">作成</dt>
+            <dd class="col-span-2"><%= l @passage.created_at, format: :long %></dd>
+
+            <dt class="opacity-70">背景色</dt>
+            <dd class="col-span-2"><code><%= @passage.bg_color.presence || "-" %></code></dd>
+
+            <dt class="opacity-70">文字色</dt>
+            <dd class="col-span-2"><code><%= @passage.text_color.presence || "-" %></code></dd>
+
+            <dt class="opacity-70">フォント</dt>
+            <dd class="col-span-2"><code><%= @passage.font_family.presence || "-" %></code></dd>
+          </dl>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <%= link_to "編集", "#", class: "btn btn-outline btn-press", disabled: true %>
+          <%= link_to "新しく記録", new_passage_path, class: "btn btn-primary btn-press" %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get "dashboard", to: "dashboard#index"
   root "top#index"  # トップページ
-  resources :passages, only: [ :new, :create ]
+  resources :passages, only: [ :new, :create, :show ]
 end


### PR DESCRIPTION
## 概要
- 一節カード部分テンプレート (_passage_card.html.erb) を修正
- デザイン用の変数 (bg / fg / ff) をテンプレート内で定義
- 本文の表示カラムを content に統一
- ダッシュボードのカードから詳細ページへのリンクを追加

## 実装内容
- _passage_card.html.erb
  - 背景色 / 文字色 / フォントを安全に取得する処理を追加
  - 本文表示を body → content に変更
  - 詳細ページリンクをカード内に追加

## 対応issue
close #25