### PR TITLE
編集機能の実装

### DIFF
--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -1,30 +1,45 @@
 class PassagesController < ApplicationController
-  before_action :authenticate_user!, except: [ :show ]
-  before_action :set_passage, only: [ :show ]
+  before_action :authenticate_user!
+  before_action :set_passage, only: [:show, :edit, :update]
+  before_action :ensure_owner!, only: [:edit, :update]
 
   def new
-    @passage = current_user.passages.build
+    @passage = current_user.passages.new
   end
 
   def create
-    @passage = current_user.passages.build(passage_params)
+    @passage = current_user.passages.new(passage_params)
     if @passage.save
-      redirect_to dashboard_path, notice: "一節を保存しました！"
+      redirect_to @passage, notice: "カードを保存したよ。"
     else
+      flash.now[:alert] = "保存に失敗しちゃった…入力を見直してね。"
       render :new, status: :unprocessable_entity
     end
   end
 
   def show
-    # 公開/非公開の概念がなければそのまま表示
-    # 自分のものだけ見せたいなら以下のような制約を後で入れる
-    # redirect_to root_path, alert: "権限がありません" unless @passage.user_id == current_user&.id
+  end
+
+  def edit
+  end
+
+  def update
+    if @passage.update(passage_params)
+      redirect_to @passage, notice: "カードを更新したよ。"
+    else
+      flash.now[:alert] = "更新に失敗しちゃった…入力を見直してね。"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private
 
   def set_passage
     @passage = Passage.find(params[:id])
+  end
+
+  def ensure_owner!
+    redirect_to @passage, alert: "これはあなたのカードじゃないみたい…" unless @passage.user_id == current_user.id
   end
 
   def passage_params

--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -1,7 +1,7 @@
 class PassagesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_passage, only: [:show, :edit, :update]
-  before_action :ensure_owner!, only: [:edit, :update]
+  before_action :set_passage, only: [ :show, :edit, :update ]
+  before_action :ensure_owner!, only: [ :edit, :update ]
 
   def new
     @passage = current_user.passages.new

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import "./preview_card"

--- a/app/javascript/preview_card.js
+++ b/app/javascript/preview_card.js
@@ -1,0 +1,57 @@
+(function () {
+  const $ = (s, el = document) => el.querySelector(s);
+  const $$ = (s, el = document) => Array.from(el.querySelectorAll(s));
+
+  const debounce = (fn, ms = 200) => {
+    let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
+  };
+
+  const init = () => {
+    const card = $("#preview-card");
+    if (!card) return; // new/edit のみ発火
+
+    const el = {
+      content:  $('[data-preview-target="content"]'),
+      title:    $('[data-preview-target="title"]'),
+      author:   $('[data-preview-target="author"]'),
+      bg:       $('[data-preview-target="bgColor"]'),
+      text:     $('[data-preview-target="textColor"]'),
+      font:     $('[data-preview-target="fontFamily"]'),
+      meta:     $("#preview-meta"),
+      body:     $("#preview-content"),
+    };
+
+    const update = () => {
+      const content = el.content?.value || "";
+      const title   = el.title?.value   || "";
+      const author  = el.author?.value  || "";
+      const bg      = el.bg?.value      || "";
+      const text    = el.text?.value    || "";
+      const font    = el.font?.value    || "";
+
+      // メタ（著者＋『タイトル』）
+      const meta = [author, title && `『${title}』`].filter(Boolean).join(" ");
+      el.meta.textContent = meta;
+
+      // 本文
+      el.body.textContent = content;
+
+      // スタイル
+      if (bg)   card.style.background = bg;
+      if (text) card.style.color = text;
+      if (font) card.style.fontFamily = font;
+    };
+
+    const onInput = debounce(update, 200);
+    $$(".input, .textarea").forEach((i) => i.addEventListener("input", onInput));
+
+    // 初期描画
+    update();
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/app/views/passages/_form.html.erb
+++ b/app/views/passages/_form.html.erb
@@ -1,0 +1,83 @@
+<%= form_with model: passage, local: true, class: "space-y-5" do |f| %>
+  <% if passage.errors.any? %>
+    <div class="alert alert-error">
+      <span>入力にエラーがあるよ（<%= passage.errors.count %>件）</span>
+      <ul class="list-disc pl-5">
+        <% passage.errors.full_messages.each do |m| %>
+          <li><%= m %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :content, "一節本文", class: "block font-semibold mb-1" %>
+    <%= f.text_area :content, rows: 5,
+          class: "textarea textarea-bordered w-full",
+          data: { preview_target: "content" } %>
+  </div>
+
+  <div class="grid gap-4 md:grid-cols-2">
+    <div>
+      <%= f.label :title, "作品タイトル", class: "block font-semibold mb-1" %>
+      <%= f.text_field :title,
+            class: "input input-bordered w-full",
+            data: { preview_target: "title" } %>
+    </div>
+    <div>
+      <%= f.label :author, "著者", class: "block font-semibold mb-1" %>
+      <%= f.text_field :author,
+            class: "input input-bordered w-full",
+            data: { preview_target: "author" } %>
+    </div>
+  </div>
+
+  <!-- カスタマイズはあとで本実装。今はテキストで置いておく -->
+  <details class="collapse collapse-arrow bg-base-200">
+    <summary class="collapse-title font-semibold">見た目のカスタマイズ（仮）</summary>
+    <div class="collapse-content grid gap-4 md:grid-cols-3">
+      <div>
+        <%= f.label :bg_color, "背景色 (例: #F9FAFB)", class: "block font-semibold mb-1" %>
+        <%= f.text_field :bg_color,
+              class: "input input-bordered w-full",
+              data: { preview_target: "bgColor" } %>
+      </div>
+      <div>
+        <%= f.label :text_color, "文字色 (例: #111827)", class: "block font-semibold mb-1" %>
+        <%= f.text_field :text_color,
+              class: "input input-bordered w-full",
+              data: { preview_target: "textColor" } %>
+      </div>
+      <div>
+        <%= f.label :font_family, "フォント (例: var(--font-serif))", class: "block font-semibold mb-1" %>
+        <%= f.text_field :font_family,
+              class: "input input-bordered w-full",
+              data: { preview_target: "fontFamily" } %>
+      </div>
+    </div>
+  </details>
+
+  <!-- ▼ ここが追加：依存ゼロのリアルタイムプレビュー -->
+  <div class="mt-8">
+    <div class="flex items-center justify-between mb-2">
+      <h2 class="text-xl font-bold gh-underline">プレビュー</h2>
+      <span class="text-sm opacity-70">入力に合わせて自動更新（遅延 200ms）</span>
+    </div>
+
+    <div id="preview-card" class="relative rounded-2xl p-6 border gh-glass"
+         style="background:<%= passage.bg_color.presence || '#F9FAFB' %>;
+                color:<%= passage.text_color.presence || '#111827' %>;
+                font-family:<%= passage.font_family.presence || 'var(--font-serif)' %>;">
+      <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
+
+      <div id="preview-meta" class="text-[11px] opacity-70 mb-1 font-sans"></div>
+      <div id="preview-content" class="text-lg md:text-2xl font-semibold leading-relaxed whitespace-pre-wrap"></div>
+    </div>
+  </div>
+  <!-- ▲ 追加ここまで -->
+
+  <div class="flex gap-2">
+    <%= f.submit (passage.persisted? ? "更新する" : "保存する"), class: "btn btn-primary" %>
+    <%= link_to "キャンセル", (passage.persisted? ? passage_path(passage) : dashboard_path), class: "btn btn-ghost" %>
+  </div>
+<% end %>

--- a/app/views/passages/edit.html.erb
+++ b/app/views/passages/edit.html.erb
@@ -1,0 +1,2 @@
+<h1 class="text-2xl font-bold mb-4">一節を編集</h1>
+<%= render "form", passage: @passage %>

--- a/app/views/passages/new.html.erb
+++ b/app/views/passages/new.html.erb
@@ -1,12 +1,2 @@
 <h1 class="text-2xl font-bold mb-4">一節を記録</h1>
-
-<%= form_with model: @passage, url: passages_path, local: true, class: "space-y-4" do |f| %>
-  <div>
-    <%= f.label :content, "一節本文", class: "block font-semibold mb-1" %>
-    <%= f.text_area :content, rows: 4, class: "textarea textarea-bordered w-full" %>
-  </div>
-
-  <div>
-    <%= f.submit "保存する", class: "btn btn-primary" %>
-  </div>
-<% end %>
+<%= render "form", passage: @passage %>

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -58,9 +58,11 @@
         </div>
 
         <div class="flex flex-wrap gap-2">
-          <%= link_to "編集", "#", class: "btn btn-outline btn-press", disabled: true %>
-          <%= link_to "新しく記録", new_passage_path, class: "btn btn-primary btn-press" %>
-        </div>
+  <% if user_signed_in? && @passage.user_id == current_user.id %>
+    <%= link_to "編集", edit_passage_path(@passage), class: "btn btn-outline btn-press" %>
+  <% end %>
+  <%= link_to "新しく記録", new_passage_path, class: "btn btn-primary btn-press" %>
+</div>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get "dashboard", to: "dashboard#index"
   root "top#index"  # トップページ
-  resources :passages, only: [ :new, :create, :show ]
+  resources :passages, only: [:new, :create, :show, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get "dashboard", to: "dashboard#index"
   root "top#index"  # トップページ
-  resources :passages, only: [:new, :create, :show, :edit, :update]
+  resources :passages, only: [ :new, :create, :show, :edit, :update ]
 end


### PR DESCRIPTION
## 概要
- 一節の編集フォームを実装し、新規作成フォームと共通化しました。
- 入力内容をリアルタイムで反映する 簡易プレビュー機能 を追加しました。

## 実装内容
- routes.rb
  - :edit, :update を追加
- PassagesController
  - edit / update アクションを実装
  - 所有者のみ編集可能なガードを追加
- app/views/passages/_form.html.erb
  - 新規作成と編集フォームを共通化
  - タイトル・著者・カスタマイズ用フィールドを追加
  - 入力内容を反映するプレビュー領域を追加
- app/views/passages/new.html.erb / edit.html.erb
  - 共通フォーム _form.html.erb を呼び出すよう変更
- app/views/passages/show.html.erb
  - 所有者のみ「編集」ボタンを表示するように修正
- app/javascript/preview_card.js を新規追加
  - フォーム入力に応じてプレビュー更新（Vanilla JS, debounce 200ms）
- app/javascript/application.js
  - import "./preview_card" を追加

## 対応issue
close #26