### PR TITLE
更新処理の完成 と 削除機能の追加

### DIFF
--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -1,7 +1,7 @@
 class PassagesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_passage, only: [ :show, :edit, :update ]
-  before_action :ensure_owner!, only: [ :edit, :update ]
+  before_action :set_passage,   only: [:show, :edit, :update, :destroy]   # ← destroy追加
+  before_action :ensure_owner!, only: [:edit, :update, :destroy]          # ← destroy追加
 
   def new
     @passage = current_user.passages.new
@@ -17,11 +17,8 @@ class PassagesController < ApplicationController
     end
   end
 
-  def show
-  end
-
-  def edit
-  end
+  def show; end
+  def edit; end
 
   def update
     if @passage.update(passage_params)
@@ -32,14 +29,26 @@ class PassagesController < ApplicationController
     end
   end
 
+  def destroy
+    if @passage.destroy
+      redirect_to dashboard_path, notice: "カードを削除しました。"
+    else
+      redirect_to @passage, alert: "削除に失敗しちゃった…もう一度試してね。"
+    end
+  end
+
   private
 
   def set_passage
-    @passage = Passage.find(params[:id])
+    @passage = Passage.find_by(id: params[:id])
+    unless @passage
+      redirect_to dashboard_path, alert: "カードが見つからないよ。" and return
+    end
   end
 
   def ensure_owner!
-    redirect_to @passage, alert: "これはあなたのカードじゃないみたい…" unless @passage.user_id == current_user.id
+    return if @passage.user_id == current_user.id
+    redirect_to @passage, alert: "これはあなたのカードじゃないみたい…" and return
   end
 
   def passage_params

--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -1,7 +1,7 @@
 class PassagesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_passage,   only: [:show, :edit, :update, :destroy]   # ← destroy追加
-  before_action :ensure_owner!, only: [:edit, :update, :destroy]          # ← destroy追加
+  before_action :set_passage,   only: [ :show, :edit, :update, :destroy ]   # ← destroy追加
+  before_action :ensure_owner!, only: [ :edit, :update, :destroy ]          # ← destroy追加
 
   def new
     @passage = current_user.passages.new

--- a/app/javascript/preview_card.js
+++ b/app/javascript/preview_card.js
@@ -3,55 +3,71 @@
   const $$ = (s, el = document) => Array.from(el.querySelectorAll(s));
 
   const debounce = (fn, ms = 200) => {
-    let t; return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), ms); };
+    let t;
+    return (...args) => {
+      clearTimeout(t);
+      t = setTimeout(() => fn(...args), ms);
+    };
   };
 
   const init = () => {
     const card = $("#preview-card");
-    if (!card) return; // new/edit のみ発火
+    if (!card) return; // new/edit ページ以外
+
+    // 二重にイベントを貼らない
+    if (card.dataset.previewBound === "1") return;
+    card.dataset.previewBound = "1";
 
     const el = {
-      content:  $('[data-preview-target="content"]'),
-      title:    $('[data-preview-target="title"]'),
-      author:   $('[data-preview-target="author"]'),
-      bg:       $('[data-preview-target="bgColor"]'),
-      text:     $('[data-preview-target="textColor"]'),
-      font:     $('[data-preview-target="fontFamily"]'),
-      meta:     $("#preview-meta"),
-      body:     $("#preview-content"),
+      content: $('[data-preview-target="content"]'),
+      title: $('[data-preview-target="title"]'),
+      author: $('[data-preview-target="author"]'),
+      bg: $('[data-preview-target="bgColor"]'),
+      text: $('[data-preview-target="textColor"]'),
+      font: $('[data-preview-target="fontFamily"]'),
+      meta: $("#preview-meta"),
+      body: $("#preview-content"),
     };
 
     const update = () => {
       const content = el.content?.value || "";
-      const title   = el.title?.value   || "";
-      const author  = el.author?.value  || "";
-      const bg      = el.bg?.value      || "";
-      const text    = el.text?.value    || "";
-      const font    = el.font?.value    || "";
+      const title = el.title?.value || "";
+      const author = el.author?.value || "";
+      const bg = el.bg?.value || "";
+      const text = el.text?.value || "";
+      const font = el.font?.value || "";
 
       // メタ（著者＋『タイトル』）
       const meta = [author, title && `『${title}』`].filter(Boolean).join(" ");
-      el.meta.textContent = meta;
+      if (el.meta) el.meta.textContent = meta;
 
       // 本文
-      el.body.textContent = content;
+      if (el.body) el.body.textContent = content;
 
       // スタイル
-      if (bg)   card.style.background = bg;
+      if (bg) card.style.background = bg;
       if (text) card.style.color = text;
       if (font) card.style.fontFamily = font;
     };
 
     const onInput = debounce(update, 200);
-    $$(".input, .textarea").forEach((i) => i.addEventListener("input", onInput));
 
-    // 初期描画
+    // 入力イベントを各フィールドにバインド
+    $$('.input, .textarea, [data-preview-target]').forEach((i) => {
+      i.addEventListener("input", onInput);
+    });
+
+    // 初期描画（ページ表示直後に現在値を反映）
     update();
   };
 
+  // Turbo でも通常ロードでも初期化が走るようにする
+  document.addEventListener("turbo:load", init);
+  document.addEventListener("turbo:frame-load", init); // フレーム内で使う場合
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init);
   } else {
+    // 初回ロード（直読み込み）の保険
     init();
   }
 })();

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -59,10 +59,11 @@
 
         <div class="flex flex-wrap gap-2">
   <% if user_signed_in? && @passage.user_id == current_user.id %>
-    <%= link_to "編集", edit_passage_path(@passage), class: "btn btn-outline btn-press" %>
-  <% end %>
-  <%= link_to "新しく記録", new_passage_path, class: "btn btn-primary btn-press" %>
-</div>
+  <%= link_to "編集", edit_passage_path(@passage), class: "btn btn-outline btn-press" %>
+  <%= link_to "削除", passage_path(@passage),
+        data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+        class: "btn btn-error btn-press" %>
+<% end %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get "dashboard", to: "dashboard#index"
   root "top#index"  # トップページ
-  resources :passages, only: [:new, :create, :show, :edit, :update, :destroy]
+  resources :passages, only: [ :new, :create, :show, :edit, :update, :destroy ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get "dashboard", to: "dashboard#index"
   root "top#index"  # トップページ
-  resources :passages, only: [ :new, :create, :show, :edit, :update ]
+  resources :passages, only: [:new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
## 概要
- 一節カードの 更新処理の完成 と 削除機能の追加 を行いました
- プレビュー機能が Turbo ナビゲーションでも初期化されるよう修正しました。

## 実装内容
- routes.rb
  - :destroy を追加
- PassagesController
  - before_action に :destroy を追加
  - update 成功時 → 詳細ページへリダイレクト & フラッシュ
  - destroy を実装（所有者のみ削除可能）
- app/views/passages/show.html.erb
  - 所有者のみ「削除」ボタンを表示
  - 削除時に Turbo 確認ダイアログを表示
- app/javascript/preview_card.js
  - Turbo (turbo:load) に対応し、ページ遷移直後でもプレビューが初期化されるよう修正

## 対応issue
close #27 