### PR TITLE
プロフィールページの作成

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,9 @@
+class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @user = current_user
+    @passages_count = @user.passages.count
+    @recent_passages = @user.passages.order(created_at: :desc).limit(12)
+  end
+end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,42 +1,72 @@
-<header class="fixed top-0 left-0 right-0 z-50 bg-base-100 shadow-sm border-b">
-  <!-- 高さは min-h で安定（SP:64px / PC:80px） -->
+<header class="fixed top-0 left-0 right-0 z-50 bg-base-100 shadow-sm border-b overflow-visible">
   <div class="min-h-16 md:min-h-20">
-    <div class="container mx-auto max-w-6xl h-full px-4 md:px-8
-                flex items-center justify-between gap-3 flex-nowrap">
+    <div class="container mx-auto max-w-6xl h-full px-4 md:px-8 flex items-center justify-between gap-3 flex-nowrap">
 
-      <!-- 左：ブランド（折り返し禁止） -->
+      <!-- 左：ブランド -->
       <%= link_to root_path, class: "btn btn-ghost h-10 min-h-10 px-2 text-xl md:text-2xl font-extrabold leading-none shrink-0" do %>
         QuoteCanvas
       <% end %>
 
-      <!-- 中央：PCナビ（縮む担当） -->
+      <!-- 中央：PCナビ -->
       <nav class="hidden lg:flex flex-1 min-w-0 justify-center">
         <ul class="menu menu-horizontal px-1 items-center truncate">
           <li><%= link_to "機能", "#{root_path}#features", class: "px-3 h-10 leading-none hover:underline underline-offset-8" %></li>
           <li><%= link_to "使い方", "#{root_path}#how", class: "px-3 h-10 leading-none hover:underline underline-offset-8" %></li>
+          <% if user_signed_in? %>
+            <li><%= link_to "ダッシュボード", dashboard_path, class: "px-3 h-10 leading-none hover:underline underline-offset-8" %></li>
+          <% end %>
         </ul>
       </nav>
 
-      <!-- 右：アクション（折り返し禁止） -->
+      <!-- 右：アクション -->
       <div class="flex items-center gap-2 shrink-0">
+
         <% if user_signed_in? %>
-          <div class="dropdown dropdown-end">
-            <button class="btn btn-ghost h-10 min-h-10 px-3">
+          <!-- クイック作成 -->
+          <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-primary h-10 min-h-10 px-3 hidden sm:inline-flex" %>
+
+          <!-- モバイルメニュー（ハンバーガー） -->
+          <div class="dropdown dropdown-end lg:hidden">
+            <button type="button" class="btn btn-ghost h-10 min-h-10 px-3" aria-haspopup="menu" aria-expanded="false">
+              ☰
+            </button>
+            <ul tabindex="0" class="menu dropdown-content z-[60] p-2 shadow bg-base-100 rounded-box w-56 mt-2">
+              <li><%= link_to "ダッシュボード", dashboard_path %></li>
+              <li><%= link_to "＋ 一節を記録", new_passage_path %></li>
+              <li><%= link_to "プロフィール", profile_path %></li>
+              <li><%= link_to "アカウント設定", edit_user_registration_path %></li>
+              <li class="menu-title mt-1">その他</li>
+              <li>
+                <%= link_to "ログアウト", destroy_user_session_path,
+                      data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" } %>
+              </li>
+            </ul>
+          </div>
+
+          <!-- ユーザードロップダウン（PC） -->
+          <div class="dropdown dropdown-end hidden lg:block">
+            <button type="button" class="btn btn-ghost h-10 min-h-10 px-3" aria-haspopup="menu" aria-expanded="false">
               <span class="hidden md:inline mr-2 truncate max-w-[10rem]">
                 <%= current_user.name.presence || "ユーザー" %>
               </span>
               <div class="avatar placeholder">
                 <div class="bg-neutral text-neutral-content rounded-full w-8">
-                  <span><%= (current_user.name.presence || "U")[0].upcase %></span>
+                  <span><%= (current_user.name.presence || current_user.email).to_s.first.upcase %></span>
                 </div>
               </div>
             </button>
-            <!-- ドロップダウンがヘッダー外へ出られるよう overflow は header で隠さない -->
             <ul tabindex="0" class="menu dropdown-content z-[60] p-2 shadow bg-base-100 rounded-box w-56 mt-2">
-              <li><%= link_to "プロフィール設定", edit_user_registration_path %></li>
-              <li><%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "btn btn-ghost text-left" %></li>
+              <li><%= link_to "ダッシュボード", dashboard_path %></li>
+              <li><%= link_to "＋ 一節を記録", new_passage_path %></li>
+              <li><%= link_to "プロフィール", profile_path %></li>
+              <li><%= link_to "アカウント設定", edit_user_registration_path %></li>
+              <li>
+                <%= link_to "ログアウト", destroy_user_session_path,
+                      data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" } %>
+              </li>
             </ul>
           </div>
+
         <% else %>
           <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost h-10 min-h-10 px-3" %>
           <%= link_to "はじめる", new_user_registration_path, class: "btn btn-primary h-10 min-h-10 px-4" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,83 @@
+<div class="fixed inset-0 -z-10 gh-sky">
+  <div class="absolute inset-0 gh-hills opacity-70"></div>
+  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
+</div>
+
+<div class="container mx-auto max-w-7xl px-4 md:px-8 py-8 md:py-12">
+  <div class="mb-6">
+    <%= link_to "← 戻る", (request.referer || dashboard_path), class: "link link-primary" %>
+  </div>
+
+  <!-- ヘッダ -->
+  <section class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden hover-float">
+    <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
+
+    <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 relative">
+      <div>
+        <h1 class="text-2xl md:text-3xl font-extrabold gh-underline">プロフィール</h1>
+        <p class="opacity-80 mt-1">
+          <%= @user.name.presence || "名前未設定" %> / <%= @user.email %>
+        </p>
+        <p class="opacity-60 text-sm mt-1">
+          登録日: <%= l(@user.created_at, format: :long) %>
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2 shrink-0">
+        <%= link_to edit_user_registration_path, class: "btn btn-primary hover-float" do %>
+          アカウント編集
+        <% end %>
+        <%= link_to dashboard_path, class: "btn btn-ghost hover-float" do %>
+          ダッシュボード
+        <% end %>
+      </div>
+    </div>
+  </section>
+
+  <!-- サマリ -->
+  <section class="mt-6 grid gap-4 sm:grid-cols-3">
+    <div class="rounded-2xl gh-glass p-5 relative hover-float">
+      <div class="text-sm opacity-70">カード総数</div>
+      <div class="text-3xl font-extrabold mt-1"><%= @passages_count %></div>
+    </div>
+    <a href="<%= root_path %>#features" class="rounded-2xl gh-glass p-5 hover-float">
+      <div class="text-sm opacity-70">カスタマイズ</div>
+      <div class="mt-1">色・フォントで“言葉の表情”を変える</div>
+    </a>
+    <div class="rounded-2xl gh-glass p-5 hover-float">
+      <div class="text-sm opacity-70">メール</div>
+      <div class="mt-1 truncate"><%= @user.email %></div>
+    </div>
+  </section>
+
+  <!-- 最近の一節 -->
+  <section class="mt-10">
+    <div class="flex items-end justify-between">
+      <div>
+        <h2 class="text-xl md:text-2xl font-bold gh-underline">最近の記録</h2>
+        <p class="opacity-70 text-sm mt-1">あなたの直近12枚を表示</p>
+      </div>
+      <%= link_to dashboard_path, class: "link link-primary" do %>
+        一覧へ →
+      <% end %>
+    </div>
+
+    <% if @recent_passages.any? %>
+      <div class="mt-5 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        <% @recent_passages.each do |p| %>
+          <%= render "dashboard/passage_card", passage: p %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="mt-6 rounded-3xl gh-glass p-10 text-center hover-float">
+        <div class="text-4xl mb-2">🌿</div>
+        <p class="font-semibold">まだカードがありません</p>
+        <p class="opacity-70 text-sm mt-1">心に残った一文を、最初の1枚に。</p>
+        <div class="mt-4">
+          <%= link_to new_passage_path, class: "btn btn-primary breeze" do %>
+            ＋ 一節を記録
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get "dashboard", to: "dashboard#index"
-  root "top#index"  # トップページ
+  root "top#index"
+  get "profile", to: "users#show", as: :profile
   resources :passages, only: [ :new, :create, :show, :edit, :update, :destroy ]
 end


### PR DESCRIPTION
## 概要
- ユーザーのプロフィールページを作成し、ヘッダーのドロップダウンメニューを改善しました。
- 自分の情報を確認できるページ /profile を追加し、ナビゲーションからアクセスしやすくしました。

## 実装内容
- ルーティング
  - get "profile", to: "users#show", as: :profile を追加
- UsersController
  - show アクションを追加（current_user の情報、カード総数、最近の一節を取得）
- ビュー
  - app/views/users/show.html.erb を作成
  - ユーザー名・メール・登録日を表示
  - カード総数と最近の一節12件をカード形式で表示
  - 「アカウント編集」ボタンを設置
- ヘッダー
  - ドロップダウンに プロフィール と ダッシュボード を追加
  - 「＋ 一節を記録」のクイックボタンを追加（PC表示のみ）
  - モバイル用にハンバーガーメニューを追加
  - ログアウトを link_to ... data: { turbo_method: :delete } に変更

## 対応issue
close #28