### PR TITLE
プロフィール編集機能の実装

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,58 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<!-- 背景 -->
+<div class="fixed inset-0 -z-10 gh-sky">
+  <div class="absolute inset-0 gh-hills opacity-70"></div>
+  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
+</div>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+<div class="container mx-auto max-w-3xl px-4 md:px-8 py-8 md:py-12">
+  <div class="mb-6">
+    <%= link_to "← 戻る", (defined?(profile_path) ? profile_path : root_path), class: "link link-primary" %>
   </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden">
+    <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full
+                bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+    <h1 class="text-2xl md:text-3xl font-extrabold gh-underline mb-6">プロフィール編集</h1>
+
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name),
+                 html: { method: :put, class: "space-y-6" }) do |f| %>
+
+      <% if resource.errors.any? %>
+        <div class="alert alert-error">
+          <span>入力にエラーがあるよ（<%= resource.errors.count %>件）</span>
+          <ul class="list-disc pl-5">
+            <% resource.errors.full_messages.each do |m| %>
+              <li><%= m %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <!-- 名前 -->
+      <div>
+        <%= f.label :name, "名前", class: "block font-semibold mb-1" %>
+        <%= f.text_field :name, class: "input input-bordered w-full" %>
+      </div>
+
+      <!-- メール -->
+      <div>
+        <%= f.label :email, "メールアドレス", class: "block font-semibold mb-1" %>
+        <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full" %>
+      </div>
+
+      <!-- Devise仕様: 確認用の現在パスワード -->
+      <div>
+        <%= f.label :current_password, "現在のパスワード（確認用）", class: "block font-semibold mb-1" %>
+        <%= f.password_field :current_password, autocomplete: "current-password",
+                             class: "input input-bordered w-full" %>
+        <p class="text-sm opacity-70 mt-1">プロフィールを更新するには現在のパスワードが必要です。</p>
+      </div>
+
+      <div class="flex gap-2">
+        <%= f.submit "更新する", class: "btn btn-primary" %>
+        <%= link_to "キャンセル", (defined?(profile_path) ? profile_path : root_path), class: "btn btn-ghost" %>
+      </div>
     <% end %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>
+</div>


### PR DESCRIPTION
## 概要
- プロフィール編集フォームを実装し、名前・メールアドレス を更新できるようにしました。
- Devise の registrations#edit を Tailwind + daisyUI の見た目に整えています。

## 実装内容
- Devise Strong Parameters
  - ApplicationController にて :account_update へ :name を許可（sign_up も許可済）
- ビュー
  - app/views/devise/registrations/edit.html.erb を作成/差し替え
    - 名前・メール・現在パスワード（Devise仕様）
    - daisyUI の input / btn / ガラス調のセクションでUI統一
- ナビゲーション
  - 既存導線（ヘッダーの「アカウント設定」= edit_user_registration_path）から遷移

## 対応issue
close #29 