### PR TITLE
思考ログ用モデル作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,4 +20,8 @@ class ApplicationController < ActionController::Base
   def after_sign_out_path_for(resource_or_scope)
     root_path
   end
+
+  def after_update_path_for(resource)
+    profile_path
+  end
 end

--- a/app/models/passage.rb
+++ b/app/models/passage.rb
@@ -1,5 +1,6 @@
 class Passage < ApplicationRecord
   belongs_to :user, optional: true  # 後で必須化してOK
+   has_many :thought_logs, dependent: :destroy
 
   validates :content, presence: true, length: { maximum: 2000 }
   validates :title, length: { maximum: 200 }, allow_blank: true

--- a/app/models/thought_log.rb
+++ b/app/models/thought_log.rb
@@ -1,0 +1,5 @@
+class ThoughtLog < ApplicationRecord
+  belongs_to :passage
+
+  validates :content, presence: true, length: { maximum: 10_000 }
+end

--- a/db/migrate/20250831072511_create_thought_logs.rb
+++ b/db/migrate/20250831072511_create_thought_logs.rb
@@ -1,0 +1,9 @@
+class CreateThoughtLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :thought_logs do |t|
+      t.text :content, null: false
+      t.references :passage, null: false, foreign_key: true, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_28_051618) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_31_072511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_051618) do
     t.bigint "user_id"
     t.text "content"
     t.index ["user_id"], name: "index_passages_on_user_id"
+  end
+
+  create_table "thought_logs", force: :cascade do |t|
+    t.text "content"
+    t.bigint "passage_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["passage_id"], name: "index_thought_logs_on_passage_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -46,4 +54,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_051618) do
   end
 
   add_foreign_key "passages", "users"
+  add_foreign_key "thought_logs", "passages"
 end

--- a/test/fixtures/thought_logs.yml
+++ b/test/fixtures/thought_logs.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  content: MyText
+  passage: one
+
+two:
+  content: MyText
+  passage: two

--- a/test/models/thought_log_test.rb
+++ b/test/models/thought_log_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ThoughtLogTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- 思考ログを保存するための ThoughtLog モデル を作成しました。
- Devise アカウント更新後のリダイレクト先を /profile に変更しました。

## 実装内容
- モデル
  - ThoughtLog モデルを新規作成
    - カラム: content:text（必須, 最大 10,000 文字）
    - passage:references（必須, 外部キー制約あり）
  - バリデーション追加：content presence / length
  - Passage に has_many :thought_logs, dependent: :destroy を追加
- マイグレーション
  - create_table :thought_logs を追加 (null: false 制約付き)
- ApplicationController
  - after_update_path_for を追加し、Devise アカウント更新後のリダイレクト先を /profile に変更

## 対応issue
close #31 