### PR TITLE
思考ログ一覧表示

### DIFF
--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -17,7 +17,10 @@ class PassagesController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @thought_logs = @passage.thought_logs.order(created_at: :desc)
+  end
+
   def edit; end
 
   def update

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -57,6 +57,51 @@
           </dl>
         </div>
 
+        <!-- 思考ログ：この一節に紐づく“考えの連鎖” -->
+<section class="mt-6">
+  <div class="flex items-end justify-between">
+    <div>
+      <h2 class="text-xl md:text-2xl font-bold gh-underline">思考ログ</h2>
+      <p class="opacity-70 text-sm mt-1"><%= @thought_logs&.size || 0 %> 件</p>
+    </div>
+
+    <% if user_signed_in? && @passage.user_id == current_user.id %>
+      <%= link_to "＋ 思考ログを追加",
+                  new_passage_thought_log_path(@passage),
+                  class: "btn btn-outline btn-press" %>
+    <% end %>
+  </div>
+
+  <% if @thought_logs.present? %>
+    <div class="mt-4 space-y-3">
+      <% @thought_logs.each do |log| %>
+        <article class="rounded-2xl gh-glass p-4 hover-float">
+          <div class="flex items-center justify-between text-xs opacity-70 mb-2">
+            <span>記録日時</span>
+            <time datetime="<%= log.created_at.iso8601 %>"><%= l log.created_at, format: :long %></time>
+          </div>
+          <div class="leading-relaxed text-sm whitespace-pre-wrap">
+            <%= h(log.content) %>
+          </div>
+        </article>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="mt-4 rounded-2xl gh-glass p-6 text-center hover-float">
+      <p class="font-semibold">まだ思考ログはありません</p>
+      <p class="opacity-70 text-sm mt-1">この一節から連想した気づきや感情を残しておこう。</p>
+      <% if user_signed_in? && @passage.user_id == current_user.id %>
+        <div class="mt-4">
+          <%= link_to "＋ 最初の思考ログを追加",
+                      new_passage_thought_log_path(@passage),
+                      class: "btn btn-primary btn-press" %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</section>
+
+
         <div class="flex flex-wrap gap-2">
   <% if user_signed_in? && @passage.user_id == current_user.id %>
   <%= link_to "編集", edit_passage_path(@passage), class: "btn btn-outline btn-press" %>


### PR DESCRIPTION
## 概要
- Passage 詳細ページに 思考ログ一覧 を追加し、対象の一節に紐づくログを確認できるようにしました。
- 所有者のみが思考ログを新規追加できるリンクを表示しました。

## 実装内容
- PassagesController
  - show アクションで @thought_logs を取得（@passage.thought_logs.order(created_at: :desc)）
- ビュー (passages/show.html.erb)
  - 「思考ログ」セクションを追加
  - ログが存在する場合 → 追加日時と本文をカード形式で表示
  - ログが無い場合 → 空状態のメッセージを表示し、最初の思考ログ追加導線を表示
  - 所有者のみ「＋ 思考ログを追加」ボタンを表示（new_passage_thought_log_path(@passage)）

## 対応issue
close #34 