### PR TITLE
カスタマイズモデル作成

### DIFF
--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -18,8 +18,13 @@ class PassagesController < ApplicationController
   end
 
   def show
-    @thought_logs = @passage.thought_logs.order(created_at: :desc)
-  end
+  @thought_logs = @passage.thought_logs.order(created_at: :desc)
+  @style = {
+    bg:   @passage.customization&.bg_color.presence || @passage.bg_color.presence || "#F9FAFB",
+    text: @passage.customization&.color.presence    || @passage.text_color.presence || "#111827",
+    font: @passage.customization&.font.presence     || @passage.font_family.presence || "var(--font-serif)"
+  }
+end
 
   def edit; end
 

--- a/app/models/passage.rb
+++ b/app/models/passage.rb
@@ -1,6 +1,8 @@
 class Passage < ApplicationRecord
   belongs_to :user, optional: true  # 後で必須化してOK
-   has_many :thought_logs, dependent: :destroy
+  has_many :thought_logs, dependent: :destroy
+  has_one :customization, class_name: "PassageCustomization", dependent: :destroy
+  accepts_nested_attributes_for :customization, update_only: true
 
   validates :content, presence: true, length: { maximum: 2000 }
   validates :title, length: { maximum: 200 }, allow_blank: true

--- a/app/models/passage_customization.rb
+++ b/app/models/passage_customization.rb
@@ -1,0 +1,11 @@
+class PassageCustomization < ApplicationRecord
+  belongs_to :passage
+  belongs_to :user
+
+  # HEXカラー簡易バリデーション
+  HEX = /\A#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\z/
+  validates :bg_color, :color, allow_blank: true, format: { with: HEX, message: "は #RRGGBB 形式で入力してね" }
+
+  validates :font, length: { maximum: 100 }, allow_blank: true
+  validates :passage_id, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :passages, dependent: :destroy
+  has_many :passage_customizations, dependent: :destroy
 end

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -1,4 +1,4 @@
-<!-- 背景：空＋丘＋粒子（トップ同様） -->
+<!-- 背景：空＋丘＋粒子 -->
 <div class="fixed inset-0 -z-10 gh-sky">
   <div class="absolute inset-0 gh-hills opacity-70"></div>
   <div class="absolute inset-0 gh-grain pointer-events-none"></div>
@@ -15,9 +15,9 @@
     <div class="grid gap-6 md:grid-cols-2 items-start">
       <!-- カード本体 -->
       <div class="relative rounded-2xl p-6 border card-lift"
-           style="background:<%= @passage.bg_color.presence || '#F9FAFB' %>;
-                  color:<%= @passage.text_color.presence || '#111827' %>;
-                  font-family:<%= @passage.font_family.presence || 'var(--font-serif)' %>;">
+           style="background:<%= @style[:bg] %>;
+                  color:<%= @style[:text] %>;
+                  font-family:<%= @style[:font] %>;">
         <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
 
         <% if @passage.title.present? || @passage.author.present? %>
@@ -47,68 +47,83 @@
             <dd class="col-span-2"><%= l @passage.created_at, format: :long %></dd>
 
             <dt class="opacity-70">背景色</dt>
-            <dd class="col-span-2"><code><%= @passage.bg_color.presence || "-" %></code></dd>
+            <dd class="col-span-2">
+              <code><%= @style[:bg] %></code>
+              <% if @passage.customization&.bg_color.present? %>
+                <span class="badge badge-ghost ml-2">custom</span>
+              <% end %>
+            </dd>
 
             <dt class="opacity-70">文字色</dt>
-            <dd class="col-span-2"><code><%= @passage.text_color.presence || "-" %></code></dd>
+            <dd class="col-span-2">
+              <code><%= @style[:text] %></code>
+              <% if @passage.customization&.color.present? %>
+                <span class="badge badge-ghost ml-2">custom</span>
+              <% end %>
+            </dd>
 
             <dt class="opacity-70">フォント</dt>
-            <dd class="col-span-2"><code><%= @passage.font_family.presence || "-" %></code></dd>
+            <dd class="col-span-2">
+              <code><%= @style[:font] %></code>
+              <% if @passage.customization&.font.present? %>
+                <span class="badge badge-ghost ml-2">custom</span>
+              <% end %>
+            </dd>
           </dl>
         </div>
 
         <!-- 思考ログ：この一節に紐づく“考えの連鎖” -->
-<section class="mt-6">
-  <div class="flex items-end justify-between">
-    <div>
-      <h2 class="text-xl md:text-2xl font-bold gh-underline">思考ログ</h2>
-      <p class="opacity-70 text-sm mt-1"><%= @thought_logs&.size || 0 %> 件</p>
-    </div>
+        <section class="mt-6">
+          <div class="flex items-end justify-between">
+            <div>
+              <h2 class="text-xl md:text-2xl font-bold gh-underline">思考ログ</h2>
+              <p class="opacity-70 text-sm mt-1"><%= @thought_logs&.size || 0 %> 件</p>
+            </div>
 
-    <% if user_signed_in? && @passage.user_id == current_user.id %>
-      <%= link_to "＋ 思考ログを追加",
-                  new_passage_thought_log_path(@passage),
-                  class: "btn btn-outline btn-press" %>
-    <% end %>
-  </div>
-
-  <% if @thought_logs.present? %>
-    <div class="mt-4 space-y-3">
-      <% @thought_logs.each do |log| %>
-        <article class="rounded-2xl gh-glass p-4 hover-float">
-          <div class="flex items-center justify-between text-xs opacity-70 mb-2">
-            <span>記録日時</span>
-            <time datetime="<%= log.created_at.iso8601 %>"><%= l log.created_at, format: :long %></time>
+            <% if user_signed_in? && @passage.user_id == current_user.id %>
+              <%= link_to "＋ 思考ログを追加",
+                          new_passage_thought_log_path(@passage),
+                          class: "btn btn-outline btn-press" %>
+            <% end %>
           </div>
-          <div class="leading-relaxed text-sm whitespace-pre-wrap">
-            <%= h(log.content) %>
-          </div>
-        </article>
-      <% end %>
-    </div>
-  <% else %>
-    <div class="mt-4 rounded-2xl gh-glass p-6 text-center hover-float">
-      <p class="font-semibold">まだ思考ログはありません</p>
-      <p class="opacity-70 text-sm mt-1">この一節から連想した気づきや感情を残しておこう。</p>
-      <% if user_signed_in? && @passage.user_id == current_user.id %>
-        <div class="mt-4">
-          <%= link_to "＋ 最初の思考ログを追加",
-                      new_passage_thought_log_path(@passage),
-                      class: "btn btn-primary btn-press" %>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-</section>
 
+          <% if @thought_logs.present? %>
+            <div class="mt-4 space-y-3">
+              <% @thought_logs.each do |log| %>
+                <article class="rounded-2xl gh-glass p-4 hover-float">
+                  <div class="flex items-center justify-between text-xs opacity-70 mb-2">
+                    <span>記録日時</span>
+                    <time datetime="<%= log.created_at.iso8601 %>"><%= l log.created_at, format: :long %></time>
+                  </div>
+                  <div class="leading-relaxed text-sm whitespace-pre-wrap">
+                    <%= h(log.content) %>
+                  </div>
+                </article>
+              <% end %>
+            </div>
+          <% else %>
+            <div class="mt-4 rounded-2xl gh-glass p-6 text-center hover-float">
+              <p class="font-semibold">まだ思考ログはありません</p>
+              <p class="opacity-70 text-sm mt-1">この一節から連想した気づきや感情を残しておこう。</p>
+              <% if user_signed_in? && @passage.user_id == current_user.id %>
+                <div class="mt-4">
+                  <%= link_to "＋ 最初の思考ログを追加",
+                              new_passage_thought_log_path(@passage),
+                              class: "btn btn-primary btn-press" %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </section>
 
         <div class="flex flex-wrap gap-2">
-  <% if user_signed_in? && @passage.user_id == current_user.id %>
-  <%= link_to "編集", edit_passage_path(@passage), class: "btn btn-outline btn-press" %>
-  <%= link_to "削除", passage_path(@passage),
-        data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-        class: "btn btn-error btn-press" %>
-<% end %>
+          <% if user_signed_in? && @passage.user_id == current_user.id %>
+            <%= link_to "編集", edit_passage_path(@passage), class: "btn btn-outline btn-press" %>
+            <%= link_to "削除", passage_path(@passage),
+                  data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+                  class: "btn btn-error btn-press" %>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/db/migrate/20250901062309_create_passage_customizations.rb
+++ b/db/migrate/20250901062309_create_passage_customizations.rb
@@ -1,0 +1,13 @@
+class CreatePassageCustomizations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :passage_customizations do |t|
+      t.string :font
+      t.string :color
+      t.string :bg_color
+      t.references :passage, null: false, foreign_key: true, index: { unique: true } # 1:1
+      t.references :user,    null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_31_072511) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_01_062309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "passage_customizations", force: :cascade do |t|
+    t.string "font"
+    t.string "color"
+    t.string "bg_color"
+    t.bigint "passage_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["passage_id"], name: "index_passage_customizations_on_passage_id", unique: true
+    t.index ["user_id"], name: "index_passage_customizations_on_user_id"
+  end
 
   create_table "passages", force: :cascade do |t|
     t.string "author"
@@ -53,6 +65,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_31_072511) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "passage_customizations", "passages"
+  add_foreign_key "passage_customizations", "users"
   add_foreign_key "passages", "users"
   add_foreign_key "thought_logs", "passages"
 end

--- a/test/fixtures/passage_customizations.yml
+++ b/test/fixtures/passage_customizations.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  font: MyString
+  color: MyString
+  bg_color: MyString
+  passage: one
+  user: one
+
+two:
+  font: MyString
+  color: MyString
+  bg_color: MyString
+  passage: two
+  user: two

--- a/test/models/passage_customization_test.rb
+++ b/test/models/passage_customization_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PassageCustomizationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- 各 Passage の見た目を拡張可能にする PassageCustomization モデルを追加しました。
- 表示側は Customization > 既存カラム > デフォルト の優先順で反映するようにし、show ページに適用済みです（フォーム連携は別Issue）。

## 実装内容
- モデル/マイグレーション
  - PassageCustomization を新規追加
    - カラム: font:string, color:string, bg_color:string, passage:references, user:references
    - passage_id に unique index（Passage と 1:1）
    - 外部キー制約（passage_id, user_id）
  - バリデーション
    - bg_color, color: #RGB / #RRGGBB のHEX形式を許可
    - font: 最大100文字
    - passage_id の一意性
- 関連付け
  - Passage に has_one :customization, class_name: "PassageCustomization", dependent: :destroy を追加
  - User に has_many :passage_customizations, dependent: :destroy を追加
- 表示ロジック
  - PassagesController#show
    - @style を組み立て（bg, text, font）。Customization → Passage既存 → デフォルトの順で解決
  - app/views/passages/show.html.erb
    - カード本体の style を @style ベースに変更
    - メタ情報の表示も実効値に合わせ、Customization 由来なら badge を表示