### PR TITLE
カスタマイズ機能保存/反映処理

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,7 +9,7 @@
     <%= link_to "← 戻る", (defined?(profile_path) ? profile_path : root_path), class: "link link-primary" %>
   </div>
 
-  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden">
+  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-visible md:overflow-visible">
     <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full
                 bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
 

--- a/app/views/passage_customizations/_color_field_with_palette.html.erb
+++ b/app/views/passage_customizations/_color_field_with_palette.html.erb
@@ -1,45 +1,36 @@
-<%# locals: f:, field:, label:, placeholder:, picker_key:, default_color: %>
+<%# locals: f:, field:, label:, picker_key:, default_color: %>
 <div>
   <%= f.label field, label, class: "block font-semibold mb-1" %>
 
-  <div class="flex gap-2 items-center">
-    <%= f.text_field field,
-          class: "input input-bordered w-full",
-          placeholder: placeholder,
-          pattern: "#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})",
-          title: "#RRGGBB 形式で入力してね",
-          data: { preview_target: (picker_key == "textColor" ? "textColor" : "bgColor") } %>
-
-    <input type="color" class="input w-12 p-0"
-           value="<%= default_color %>"
-           data-colorpicker="<%= picker_key %>" />
-
-    <span class="badge"><%= (default_color || "").upcase %></span>
-  </div>
-
-  <%# よく使うプリセット %>
-  <% presets = %w[
-    #111827 #374151 #6B7280 #9CA3AF #E5E7EB #F9FAFB
-    #EF4444 #F59E0B #10B981 #3B82F6 #8B5CF6 #EC4899
-  ] %>
-  <div class="mt-2 flex flex-wrap gap-2">
-    <% presets.each do |hex| %>
+  <!-- プリセット（お好みで色追加OK） -->
+  <div class="flex flex-wrap gap-2 mb-2">
+    <% [
+      "#111827", "#374151", "#6B7280", "#9CA3AF", "#F9FAFB",
+      "#000000", "#FFFFFF", "#EF4444", "#F59E0B", "#10B981",
+      "#3B82F6", "#8B5CF6", "#EC4899"
+    ].each do |hex| %>
       <button type="button"
-              class="size-7 rounded-full border"
+              class="size-6 rounded-full border"
               style="background:<%= hex %>"
               title="<%= hex %>"
               data-color-preset="<%= picker_key %>"
               data-value="<%= hex %>"></button>
     <% end %>
-    <button type="button" class="btn btn-xs btn-ghost"
-            data-pick-current="<%= picker_key %>">現在値を使う</button>
-    <button type="button" class="btn btn-xs"
-            data-clear-color="<%= picker_key %>">未指定にする</button>
   </div>
 
-  <%# 最近使った色（localStorage） %>
-  <div class="mt-2 flex items-center gap-2 text-xs opacity-70">
-    <span>最近：</span>
-    <div class="flex flex-wrap gap-2" data-recent="<%= picker_key %>"></div>
+  <div class="flex items-center gap-2">
+    <%= f.text_field field,
+          class: "input input-bordered w-full",
+          placeholder: default_color,
+          value: default_color,
+          data: { preview_target: picker_key } %>
+    <input type="color"
+           class="input w-12 p-0"
+           value="<%= default_color %>"
+           data-colorpicker="<%= picker_key %>" />
+    <span class="badge"><%= default_color.upcase %></span>
   </div>
+
+  <!-- 最近使った色（JSで差し込む） -->
+  <div class="mt-2 flex flex-wrap gap-2" data-recent="<%= picker_key %>"></div>
 </div>

--- a/app/views/passage_customizations/_form.html.erb
+++ b/app/views/passage_customizations/_form.html.erb
@@ -1,4 +1,5 @@
 <%# locals: customization:, passage:, url:, submit_label:, fallback: { bg:, text:, font: } %>
+
 <%= form_with model: customization,
               url: url,
               local: true,
@@ -19,59 +20,9 @@
   <% end %>
 
   <div class="grid gap-6 md:grid-cols-2 items-start">
-    <!-- 左：フォーム -->
-    <div class="space-y-5">
-      <!-- フォント -->
-      <div>
-        <%= f.label :font, "フォント", class: "block font-semibold mb-1" %>
-        <div class="flex gap-2 mb-2">
-          <% [["Serif","var(--font-serif)"],["Sans","var(--font-sans)"],["Mono","var(--font-mono)"]].each do |label, val| %>
-            <button type="button" class="btn btn-xs" data-quick-font="<%= val %>"><%= label %></button>
-          <% end %>
-        </div>
-        <%= f.select :font,
-              options_for_select([
-                ["標準（Serif）", "var(--font-serif)"],
-                ["標準（Sans）",  "var(--font-sans)"],
-                ["等幅（Mono）",  "var(--font-mono)"]
-              ], customization.font),
-              { include_blank: "（未選択 = 既定）" },
-              class: "select select-bordered w-full",
-              data: { preview_target: "font" },
-              aria: { describedby: "font-help" } %>
-        <p id="font-help" class="text-xs opacity-70 mt-1">未選択ならシステム既定が使われるよ。</p>
-        <% if customization.errors[:font].present? %>
-          <p class="text-error text-xs mt-1"><%= customization.errors[:font].first %></p>
-        <% end %>
-      </div>
-
-      <!-- 文字色 -->
-      <%= render "color_field_with_palette",
-            f: f,
-            field: :color,
-            label: "文字色 (#RRGGBB / #RGB)",
-            placeholder: "#111827",
-            picker_key: "textColor",
-            default_color: customization.color.presence || fallback[:text] %>
-
-      <!-- 背景色 -->
-      <%= render "color_field_with_palette",
-            f: f,
-            field: :bg_color,
-            label: "背景色 (#RRGGBB / #RGB)",
-            placeholder: "#F9FAFB",
-            picker_key: "bgColor",
-            default_color: customization.bg_color.presence || fallback[:bg] %>
-
-      <div class="flex gap-2">
-        <%= f.submit submit_label, class: "btn btn-primary" %>
-        <%= link_to "キャンセル", passage_path(passage), class: "btn btn-ghost" %>
-      </div>
-    </div>
-
-    <!-- 右：sticky プレビュー -->
-    <div class="md:sticky md:top-20">
-      <div id="c-preview"
+    <!-- ① SPではプレビュー先頭 / md以上は右側に固定 -->
+    <div class="order-1 md:order-2 md:sticky md:top-24">
+      <div id="preview-card"
            class="relative rounded-2xl p-6 border card-lift"
            style="background:<%= fallback[:bg] %>; color:<%= fallback[:text] %>; font-family:<%= fallback[:font] %>;"
            data-fallback-bg="<%= fallback[:bg] %>"
@@ -90,24 +41,71 @@
         </div>
       </div>
     </div>
+
+    <!-- ② 入力（SPでは後ろ / md以上は左） -->
+    <div class="order-2 md:order-1 space-y-5">
+      <!-- フォント -->
+      <div>
+        <%= f.label :font, "フォント", class: "block font-semibold mb-1" %>
+        <div class="flex gap-2 mb-2">
+          <% [["Serif","var(--font-serif)"],["Sans","var(--font-sans)"],["Mono","var(--font-mono)"]].each do |label, val| %>
+            <button type="button" class="btn btn-xs" data-quick-font="<%= val %>"><%= label %></button>
+          <% end %>
+        </div>
+        <%= f.select :font,
+              options_for_select([
+                ["標準（Serif）", "var(--font-serif)"],
+                ["標準（Sans）",  "var(--font-sans)"],
+                ["等幅（Mono）",  "var(--font-mono)"]
+              ], customization.font),
+              { include_blank: "（未選択 = 既定）" },
+              class: "select select-bordered w-full",
+              data: { preview_target: "font" } %>
+        <p class="text-xs opacity-70 mt-1">未選択ならカード既定のフォントが使われるよ。</p>
+      </div>
+
+      <!-- 文字色 -->
+      <%= render "passage_customizations/color_field_with_palette",
+            f: f,
+            field: :color,
+            label: "文字色",
+            picker_key: "textColor",
+            default_color: customization.color.presence || fallback[:text] %>
+
+      <!-- 背景色 -->
+      <%= render "passage_customizations/color_field_with_palette",
+            f: f,
+            field: :bg_color,
+            label: "背景色",
+            picker_key: "bgColor",
+            default_color: customization.bg_color.presence || fallback[:bg] %>
+
+      <div class="flex gap-2">
+        <%= f.submit submit_label, class: "btn btn-primary" %>
+        <%= link_to "キャンセル", passage_path(passage), class: "btn btn-ghost" %>
+      </div>
+    </div>
   </div>
 <% end %>
 
-<script>
-(function () {
-  // より堅牢に（祖先 .rounded-3xl -> form -> document の順で探す）
-  const root =
-    document.currentScript.closest(".rounded-3xl") ||
-    document.currentScript.closest("form") ||
-    document;
+<!-- ③ SP専用：プレビューへジャンプするFAB -->
+<button id="jump-preview"
+        class="md:hidden fixed bottom-4 right-4 btn btn-primary shadow-lg hidden"
+        type="button" aria-label="プレビューへ">
+  👁 プレビュー
+</button>
 
-  // 参照
-  const card    = root.querySelector("#c-preview");
+<!-- ④ 最小JS：双方向バインド + 初期反映 + FAB表示制御 -->
+<script>
+(() => {
+  const root = document.currentScript.closest(".rounded-3xl") || document;
+  const card = root.querySelector("#preview-card");
   const fontSel = root.querySelector('[data-preview-target="font"]');
   const textInp = root.querySelector('[data-preview-target="textColor"]');
   const bgInp   = root.querySelector('[data-preview-target="bgColor"]');
   const textPick= root.querySelector('input[data-colorpicker="textColor"]');
   const bgPick  = root.querySelector('input[data-colorpicker="bgColor"]');
+  const fab     = root.querySelector("#jump-preview");
 
   const FALLBACK = {
     font: card?.dataset.fallbackFont || "var(--font-serif)",
@@ -118,17 +116,10 @@
   const apply = () => {
     if (card) {
       card.style.fontFamily = (fontSel?.value?.trim() || FALLBACK.font);
+      card.style.color      = (textInp?.value?.trim() || FALLBACK.text);
+      card.style.background = (bgInp  ?.value?.trim() || FALLBACK.bg);
     }
-    const setColor = (key, input) => {
-      const val = (input?.value || "").trim();
-      if (!card) return;
-      if (key === "text") card.style.color = val || FALLBACK.text;
-      if (key === "bg")   card.style.background = val || FALLBACK.bg;
-    };
-    setColor("text", textInp);
-    setColor("bg",   bgInp);
-
-    // バッジの HEX 表示も更新
+    // バッジ更新（パレット側で .badge を用意している場合）
     root.querySelectorAll('[data-colorpicker]').forEach((picker) => {
       const key = picker.dataset.colorpicker;
       const src = key === "textColor" ? textInp : bgInp;
@@ -138,54 +129,11 @@
     });
   };
 
-  // ピッカー <-> テキスト 双方向
   const bindPair = (text, picker) => {
     if (!text || !picker) return;
-    picker.addEventListener("input", e => {
-      text.value = e.target.value;
-      apply(); saveRecent(text, e.target.value);
-    });
-    text.addEventListener("input", e => {
-      const v = e.target.value;
-      if (/^#(?:[0-9a-fA-F]{3}){1,2}$/.test(v)) picker.value = v;
-      apply();
-    });
+    picker.addEventListener("input", e => { text.value = e.target.value; apply(); });
+    text.addEventListener("input",  e => { if (/^#(?:[0-9a-fA-F]{3}){1,2}$/.test(e.target.value)) picker.value = e.target.value; apply(); });
   };
-
-  // プリセット
-  root.querySelectorAll('[data-color-preset]').forEach(btn => {
-    btn.addEventListener("click", (e) => {
-      const key = e.currentTarget.dataset.colorPreset;
-      const val = e.currentTarget.dataset.value;
-      const text   = key === "textColor" ? textInp : bgInp;
-      const picker = key === "textColor" ? textPick : bgPick;
-      if (text) text.value = val;
-      if (picker) picker.value = val;
-      apply(); saveRecent(text, val);
-    });
-  });
-
-  // 未指定
-  root.querySelectorAll('[data-clear-color]').forEach(btn => {
-    btn.addEventListener("click", (e) => {
-      const key = e.currentTarget.dataset.clearColor;
-      const text = key === "textColor" ? textInp : bgInp;
-      if (text) text.value = "";
-      apply();
-    });
-  });
-
-  // 現在値を拾う
-  root.querySelectorAll('[data-pick-current]').forEach(btn => {
-    btn.addEventListener("click", (e) => {
-      const key = e.currentTarget.dataset.pickCurrent;
-      const text = key === "textColor" ? textInp : bgInp;
-      const prop = key === "textColor" ? "color" : "backgroundColor";
-      const val = card ? rgbToHex(getComputedStyle(card)[prop]) : "";
-      if (text && val) text.value = val;
-      apply(); saveRecent(text, val);
-    });
-  });
 
   // クイックフォント
   root.querySelectorAll('[data-quick-font]').forEach(btn => {
@@ -196,57 +144,21 @@
     });
   });
 
-  function rgbToHex(rgb) {
-    const m = rgb.match(/\d+/g);
-    if (!m) return "";
-    return "#" + m.slice(0, 3).map(n => ("0" + parseInt(n, 10).toString(16)).slice(-2)).join("");
+  // FAB表示制御（プレビューが画面外に出たら表示）
+  if (card && fab && "IntersectionObserver" in window) {
+    const io = new IntersectionObserver(([ent]) => {
+      fab.classList.toggle("hidden", ent.isIntersecting);
+    }, { threshold: 0.1 });
+    io.observe(card);
+
+    fab.addEventListener("click", () => {
+      card.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
   }
 
-  // 最近使った色（localStorage）
-  function saveRecent(inputEl, hex) {
-    if (!hex || !hex.startsWith("#")) return;
-    const key = inputEl === textInp ? "recent_text" : "recent_bg";
-    const arr = JSON.parse(localStorage.getItem(key) || "[]").filter(v => v !== hex);
-    arr.unshift(hex);
-    localStorage.setItem(key, JSON.stringify(arr.slice(0, 8)));
-    renderRecent();
-  }
-
-  function renderRecent() {
-    const wrapText = root.querySelector('[data-recent="textColor"]');
-    const wrapBg   = root.querySelector('[data-recent="bgColor"]');
-    const make = (hex, key) => {
-      const b = document.createElement("button");
-      b.type = "button";
-      b.title = hex;
-      b.className = "size-6 rounded-full border";
-      b.style.background = hex;
-      b.dataset.colorPreset = key;
-      b.dataset.value = hex;
-      b.addEventListener("click", () => {
-        const text = key === "textColor" ? textInp : bgInp;
-        const picker = key === "textColor" ? textPick : bgPick;
-        if (text) text.value = hex;
-        if (picker) picker.value = hex;
-        apply(); saveRecent(text, hex);
-      });
-      return b;
-    };
-    if (wrapText) {
-      wrapText.innerHTML = "";
-      (JSON.parse(localStorage.getItem("recent_text") || "[]")).forEach(hex => wrapText.appendChild(make(hex, "textColor")));
-    }
-    if (wrapBg) {
-      wrapBg.innerHTML = "";
-      (JSON.parse(localStorage.getItem("recent_bg") || "[]")).forEach(hex => wrapBg.appendChild(make(hex, "bgColor")));
-    }
-  }
-
+  fontSel?.addEventListener("change", apply);
   bindPair(textInp, textPick);
   bindPair(bgInp,   bgPick);
-  fontSel?.addEventListener("change", apply);
-
-  renderRecent();
   apply(); // 初期反映
 })();
 </script>

--- a/app/views/passage_customizations/edit.html.erb
+++ b/app/views/passage_customizations/edit.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto max-w-5xl px-4 md:px-8 py-8 md:py-12 rounded-3xl gh-glass relative overflow-hidden">
   <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
-  <h1 class="text-2xl md:text-3xl font-extrabold gh-underline mb-6">カスタマイズを設定</h1>
+  <h1 class="text-2xl md:text-3xl font-extrabold gh-underline mb-6">カスタマイズを編集</h1>
 
   <%= render "passage_customizations/form",
       customization: @customization,
       passage: @passage,
-      url: passage_customization_path(@passage),  # POST
-      submit_label: "保存する",
+      url: passage_customization_path(@passage),  # PATCH/PUT
+      submit_label: "更新する",
       fallback: {
         bg:   @passage.customization&.bg_color.presence || @passage.bg_color.presence    || "#F9FAFB",
         text: @passage.customization&.color.presence    || @passage.text_color.presence  || "#111827",

--- a/app/views/passages/_form.html.erb
+++ b/app/views/passages/_form.html.erb
@@ -1,7 +1,13 @@
+<% style_bg   = passage.customization&.bg_color.presence   || passage.bg_color.presence    || "#F9FAFB" %>
+<% style_text = passage.customization&.color.presence      || passage.text_color.presence  || "#111827" %>
+<% style_font = passage.customization&.font.presence       || passage.font_family.presence || "var(--font-serif)" %>
+
+
 <%= form_with model: passage,
               local: true,
               html: { id: "passage-form", autocomplete: "off" },
               class: "space-y-6" do |f| %>
+
   <% if passage.errors.any? %>
     <div class="alert alert-error">
       <span>入力にエラーがあるよ（<%= passage.errors.count %>件）</span>
@@ -13,224 +19,375 @@
     </div>
   <% end %>
 
-  <!-- 本文 -->
-  <div>
-    <%= f.label :content, "一節本文", class: "block font-semibold mb-1" %>
-    <%= f.text_area :content, rows: 5,
-          class: "textarea textarea-bordered w-full",
-          data: { preview_target: "content" } %>
-  </div>
+  <%# ====== 2カラム（md以上で分割 / スマホは1カラム） ====== %>
+  <div class="grid gap-6 md:grid-cols-2 items-start">
+    <%# ================= 左：入力カラム ================= %>
+    <div class="space-y-6">
 
-  <!-- タイトル / 著者 -->
-  <div class="grid gap-4 md:grid-cols-2">
-    <div>
-      <%= f.label :title, "作品タイトル", class: "block font-semibold mb-1" %>
-      <%= f.text_field :title,
-            class: "input input-bordered w-full",
-            data: { preview_target: "title" } %>
-    </div>
-    <div>
-      <%= f.label :author, "著者", class: "block font-semibold mb-1" %>
-      <%= f.text_field :author,
-            class: "input input-bordered w-full",
-            data: { preview_target: "author" } %>
-    </div>
-  </div>
-
-  <!-- 見た目のカスタマイズ（作成時にも軽く設定できる） -->
-  <details class="collapse collapse-arrow bg-base-200 mt-2">
-    <summary class="collapse-title font-semibold">見た目のカスタマイズ（簡易）</summary>
-    <div class="collapse-content grid gap-4 md:grid-cols-3">
-      <%= f.fields_for :customization do |c| %>
-      <%= c.hidden_field :id if c.object&.persisted? %>
-        <div>
-          <%= c.label :font, "フォント", class: "block font-semibold mb-1" %>
-          <%= c.select :font,
-                options_for_select([
-                  ["標準（Serif）", "var(--font-serif)"],
-                  ["標準（Sans）",  "var(--font-sans)"],
-                  ["等幅（Mono）",  "var(--font-mono)"]
-                ], c.object&.font),
-                { include_blank: "（未選択 = 既定）" },
-                class: "select select-bordered w-full",
-                data: { preview_target: "font" } %>
-        </div>
-
-        <div>
-          <%= c.label :color, "文字色 (#RRGGBB / #RGB)", class: "block font-semibold mb-1" %>
-          <div class="flex gap-2">
-            <%= c.text_field :color,
-                  class: "input input-bordered w-full",
-                  placeholder: "#111827",
-                  pattern: "#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})",
-                  title: "#RRGGBB 形式で入力してね（例: #111827）",
-                  data: { preview_target: "textColor" } %>
-            <input type="color" class="input w-12 p-0"
-                   value="<%= (c.object&.color.presence || passage.customization&.color.presence || passage.text_color.presence || '#111827') %>"
-                   data-colorpicker="textColor" />
-          </div>
-        </div>
-
-        <div>
-          <%= c.label :bg_color, "背景色 (#RRGGBB / #RGB)", class: "block font-semibold mb-1" %>
-          <div class="flex gap-2">
-            <%= c.text_field :bg_color,
-                  class: "input input-bordered w-full",
-                  placeholder: "#F9FAFB",
-                  pattern: "#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})",
-                  title: "#RRGGBB 形式で入力してね（例: #F9FAFB）",
-                  data: { preview_target: "bgColor" } %>
-            <input type="color" class="input w-12 p-0"
-                   value="<%= (c.object&.bg_color.presence || passage.customization&.bg_color.presence || passage.bg_color.presence || '#F9FAFB') %>"
-                   data-colorpicker="bgColor" />
-          </div>
-        </div>
-      <% end %>
-    </div>
-  </details>
-
-  <!-- 専用ページでガッツリ調整したい人向けの導線（保存済み時のみ） -->
-  <div class="mt-2">
-    <% if passage.persisted? %>
-      <% if passage.customization.present? %>
-        <%= link_to "見た目をカスタマイズ（詳細設定）",
-              edit_passage_customization_path(passage),
-              class: "btn btn-outline" %>
-      <% else %>
-        <%= link_to "見た目をカスタマイズ（詳細設定）",
-              new_passage_customization_path(passage),
-              class: "btn btn-outline" %>
-      <% end %>
-    <% else %>
-      <button class="btn btn-outline" disabled>見た目をカスタマイズ（詳細設定）</button>
-      <p class="text-xs opacity-70 mt-1">※ まず本文を保存してから詳細カスタマイズできるよ</p>
-    <% end %>
-  </div>
-
-  <!-- プレビュー（Customization > 旧カラム > デフォルト） -->
-  <% style_bg   = passage.customization&.bg_color.presence   || passage.bg_color.presence    || "#F9FAFB" %>
-  <% style_text = passage.customization&.color.presence      || passage.text_color.presence  || "#111827" %>
-  <% style_font = passage.customization&.font.presence       || passage.font_family.presence || "var(--font-serif)" %>
-
-  <div class="mt-8">
-    <div class="flex items-center justify-between mb-2">
-      <h2 class="text-xl font-bold gh-underline">プレビュー</h2>
-      <span class="text-sm opacity-70">入力に合わせて自動更新</span>
-    </div>
-
-    <div id="preview-card" class="relative rounded-2xl p-6 border gh-glass"
-         style="background:<%= style_bg %>; color:<%= style_text %>; font-family:<%= style_font %>;"
-         data-fallback-bg="<%= style_bg %>"
-         data-fallback-text="<%= style_text %>"
-         data-fallback-font="<%= style_font %>">
-      <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
-
-      <div id="preview-meta" class="text-[11px] opacity-70 mb-1 font-sans">
-        <% meta = [f.object.author.presence, f.object.title.presence&.yield_self { |t| "『#{t}』" }].compact.join(" ") %>
-        <%= meta %>
+      <!-- 本文 -->
+      <div>
+        <%= f.label :content, "一節本文", class: "block font-semibold mb-1" %>
+        <%= f.text_area :content, rows: 5,
+              class: "textarea textarea-bordered w-full",
+              data: { preview_target: "content" } %>
       </div>
 
-      <div id="preview-content"
-           class="text-lg md:text-2xl font-semibold leading-relaxed whitespace-pre-wrap"></div>
-    </div>
-  </div>
+      <!-- タイトル / 著者 -->
+      <div class="grid gap-4 md:grid-cols-2">
+        <div>
+          <%= f.label :title, "作品タイトル", class: "block font-semibold mb-1" %>
+          <%= f.text_field :title,
+                class: "input input-bordered w-full",
+                data: { preview_target: "title" } %>
+        </div>
+        <div>
+          <%= f.label :author, "著者", class: "block font-semibold mb-1" %>
+          <%= f.text_field :author,
+                class: "input input-bordered w-full",
+                data: { preview_target: "author" } %>
+        </div>
+      </div>
 
-  <div class="flex gap-2">
-    <%= f.submit (passage.persisted? ? "更新する" : "保存する"), class: "btn btn-primary" %>
-    <%= link_to "キャンセル",
-          (passage.persisted? ? passage_path(passage) : dashboard_path),
-          class: "btn btn-ghost" %>
+      <!-- 見た目のカスタマイズ（簡易） -->
+      <details class="collapse collapse-arrow bg-base-200 mt-2">
+        <summary class="collapse-title font-semibold">見た目のカスタマイズ（簡易）</summary>
+        <div class="collapse-content grid gap-4 md:grid-cols-3">
+          <%= f.fields_for :customization do |c| %>
+            <%= c.hidden_field :id if c.object&.persisted? %>
+
+            <!-- フォント -->
+            <div>
+              <%= c.label :font, "フォント", class: "block font-semibold mb-1" %>
+              <div class="flex gap-2 mb-2">
+                <% [["Serif","var(--font-serif)"],["Sans","var(--font-sans)"],["Mono","var(--font-mono)"]].each do |label, val| %>
+                  <button type="button" class="btn btn-xs" data-quick-font="<%= val %>"><%= label %></button>
+                <% end %>
+              </div>
+              <%= c.select :font,
+                    options_for_select([
+                      ["標準（Serif）", "var(--font-serif)"],
+                      ["標準（Sans）",  "var(--font-sans)"],
+                      ["等幅（Mono）",  "var(--font-mono)"]
+                    ], c.object&.font),
+                    { include_blank: "（未選択 = 既定）" },
+                    class: "select select-bordered w-full",
+                    data: { preview_target: "font" } %>
+            </div>
+
+            <!-- 文字色 -->
+            <div>
+              <%= c.label :color, "文字色 (#RRGGBB / #RGB)", class: "block font-semibold mb-1" %>
+              <div class="flex items-center gap-2">
+                <%= c.text_field :color,
+                      class: "input input-bordered w-full",
+                      placeholder: "#111827",
+                      pattern: "#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})",
+                      title: "#RRGGBB 形式で入力してね（例: #111827）",
+                      data: { preview_target: "textColor" } %>
+                <input type="color" class="input w-12 p-0"
+                       value="<%= (c.object&.color.presence || passage.customization&.color.presence || passage.text_color.presence || '#111827') %>"
+                       data-colorpicker="textColor" />
+              </div>
+              <div class="flex flex-wrap gap-2 mt-2">
+                <% [["#111827","濃いグレー"],["#1F2937","Gray-800"],["#374151","Gray-700"],["#000000","Black"]].each do |hex, name| %>
+                  <button type="button" class="btn btn-xs" title="<%= name %>"
+                          data-color-preset="textColor" data-value="<%= hex %>">
+                    <span class="inline-block size-3 rounded-full mr-1" style="background:<%= hex %>"></span><%= name %>
+                  </button>
+                <% end %>
+                <button type="button" class="btn btn-xs" data-clear-color="textColor">未指定に戻す</button>
+                <button type="button" class="btn btn-xs" data-pick-current="textColor">現在色を拾う</button>
+              </div>
+              <div class="flex items-center gap-2 mt-2">
+                <span class="badge">HEX</span>
+                <div class="flex gap-1" data-recent="textColor"></div>
+              </div>
+            </div>
+
+            <!-- 背景色 -->
+            <div>
+              <%= c.label :bg_color, "背景色 (#RRGGBB / #RGB)", class: "block font-semibold mb-1" %>
+              <div class="flex items-center gap-2">
+                <%= c.text_field :bg_color,
+                      class: "input input-bordered w-full",
+                      placeholder: "#F9FAFB",
+                      pattern: "#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})",
+                      title: "#RRGGBB 形式で入力してね（例: #F9FAFB）",
+                      data: { preview_target: "bgColor" } %>
+                <input type="color" class="input w-12 p-0"
+                       value="<%= (c.object&.bg_color.presence || passage.customization&.bg_color.presence || passage.bg_color.presence || '#F9FAFB') %>"
+                       data-colorpicker="bgColor" />
+              </div>
+              <div class="flex flex-wrap gap-2 mt-2">
+                <% [["#F9FAFB","ほぼ白"],["#F3F4F6","Gray-100"],["#E5E7EB","Gray-200"],["#FFFFFF","White"]].each do |hex, name| %>
+                  <button type="button" class="btn btn-xs" title="<%= name %>"
+                          data-color-preset="bgColor" data-value="<%= hex %>">
+                    <span class="inline-block size-3 rounded-full mr-1 border" style="background:<%= hex %>"></span><%= name %>
+                  </button>
+                <% end %>
+                <button type="button" class="btn btn-xs" data-clear-color="bgColor">未指定に戻す</button>
+                <button type="button" class="btn btn-xs" data-pick-current="bgColor">現在色を拾う</button>
+              </div>
+              <div class="flex items-center gap-2 mt-2">
+                <span class="badge">HEX</span>
+                <div class="flex gap-1" data-recent="bgColor"></div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </details>
+
+      <!-- 詳細設定ページへの導線 -->
+      <div class="mt-2">
+        <% if passage.persisted? %>
+          <% if passage.customization.present? %>
+            <%= link_to "見た目をカスタマイズ（詳細設定）",
+                  edit_passage_customization_path(passage),
+                  class: "btn btn-outline" %>
+          <% else %>
+            <%= link_to "見た目をカスタマイズ（詳細設定）",
+                  new_passage_customization_path(passage),
+                  class: "btn btn-outline" %>
+          <% end %>
+        <% else %>
+          <button class="btn btn-outline" disabled>見た目をカスタマイズ（詳細設定）</button>
+          <p class="text-xs opacity-70 mt-1">※ まず本文を保存してから詳細カスタマイズできるよ</p>
+        <% end %>
+      </div>
+
+      <!-- 送信ボタン -->
+      <div class="flex gap-2">
+        <%= f.submit (passage.persisted? ? "更新する" : "保存する"), class: "btn btn-primary" %>
+        <%= link_to "キャンセル",
+              (passage.persisted? ? passage_path(passage) : dashboard_path),
+              class: "btn btn-ghost" %>
+      </div>
+    </div>
+
+    <%# ================= 右：PC用 sticky プレビュー ================= %>
+
+    <div class="hidden md:block md:sticky md:top-24">
+      <div class="mb-2">
+        <h2 class="text-xl font-bold gh-underline">プレビュー</h2>
+        <p class="text-sm opacity-70">入力に合わせて自動更新</p>
+      </div>
+
+      <div id="preview-card-desktop"
+           class="relative rounded-2xl p-6 border gh-glass"
+           style="background:<%= style_bg %>; color:<%= style_text %>; font-family:<%= style_font %>;">
+        <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
+
+        <div id="preview-meta-desktop" class="text-[11px] opacity-70 mb-1 font-sans">
+          <% meta = [f.object.author.presence, f.object.title.presence&.yield_self { |t| "『#{t}』" }].compact.join(" ") %>
+          <%= meta %>
+        </div>
+        <div id="preview-content-desktop"
+             class="text-lg md:text-2xl font-semibold leading-relaxed whitespace-pre-wrap"></div>
+      </div>
+    </div>
   </div>
 <% end %>
 
-<!-- 最小のプレビュー更新スクリプト（Stimulus不要・依存ゼロ） -->
+<%# ================= モバイル用：下固定ミニプレビューバー ================= %>
+<div class="md:hidden fixed inset-x-0 bottom-0 z-40">
+  <div class="mx-auto max-w-7xl px-4" style="padding-bottom: env(safe-area-inset-bottom);">
+    <div class="rounded-xl border gh-glass p-3 shadow-lg backdrop-blur">
+      <div id="preview-card-mobile"
+           class="rounded-lg p-3"
+           style="background:<%= style_bg %>; color:<%= style_text %>; font-family:<%= style_font %>; max-height: 28vh; overflow:auto;">
+        <div class="text-[10px] opacity-70 mb-1 font-sans" id="preview-meta-mobile"></div>
+        <div class="text-base font-semibold leading-relaxed whitespace-pre-wrap" id="preview-content-mobile"></div>
+      </div>
+      <div class="mt-2 flex justify-end">
+        <button type="button" class="btn btn-xs" id="toggle-mobile-preview">展開/収納</button>
+      </div>
+    </div>
+  </div>
+</div>
+<%# モバイルで固定バーに隠れないよう余白を確保 %>
+<div class="h-28 md:hidden"></div>
+
+<%# ================= プレビュー反映スクリプト（PC/モバイル対応） ================= %>
 <script>
-(function boot() {
-  const run = () => {
-    const form = document.getElementById("passage-form");
-    if (!form) return;
+(function(){
+  const form = document.getElementById("passage-form") || document.querySelector("form");
+  if (!form) return;
 
-    const metaEl    = form.querySelector("#preview-meta");
-    const contentEl = form.querySelector("#preview-content");
-    const title     = form.querySelector('[data-preview-target="title"]');
-    const author    = form.querySelector('[data-preview-target="author"]');
-    const body      = form.querySelector('[data-preview-target="content"]');
+  // 入力
+  const title  = form.querySelector('[data-preview-target="title"]');
+  const author = form.querySelector('[data-preview-target="author"]');
+  const body   = form.querySelector('[data-preview-target="content"]');
+  const fontSel= form.querySelector('[data-preview-target="font"]');
+  const textInp= form.querySelector('[data-preview-target="textColor"]');
+  const bgInp  = form.querySelector('[data-preview-target="bgColor"]');
+  const textPick = form.querySelector('input[data-colorpicker="textColor"]');
+  const bgPick   = form.querySelector('input[data-colorpicker="bgColor"]');
 
-    // カスタマイズ入力（text + color）
-    const fontSel     = form.querySelector('[data-preview-target="font"]');
-    const textInp     = form.querySelector('[data-preview-target="textColor"]');
-    const bgInp       = form.querySelector('[data-preview-target="bgColor"]');
-    const textPicker  = form.querySelector('input[data-colorpicker="textColor"]');
-    const bgPicker    = form.querySelector('input[data-colorpicker="bgColor"]');
+  // PC
+  const cardD = document.getElementById('preview-card-desktop');
+  const metaD = document.getElementById('preview-meta-desktop');
+  const contD = document.getElementById('preview-content-desktop');
 
-    const card = form.querySelector("#preview-card");
-    const FALLBACK = {
-      font: card?.dataset.fallbackFont || "var(--font-serif)",
-      text: card?.dataset.fallbackText || "#111827",
-      bg:   card?.dataset.fallbackBg   || "#F9FAFB",
-    };
+  // モバイル
+  const cardM = document.getElementById('preview-card-mobile');
+  const metaM = document.getElementById('preview-meta-mobile');
+  const contM = document.getElementById('preview-content-mobile');
 
-    const updateMeta = () => {
-      const a = (author?.value || "").trim();
-      const t = (title?.value  || "").trim();
-      metaEl && (metaEl.textContent = [a, t ? `『${t}』` : null].filter(Boolean).join(" "));
-    };
-
-    const updateBody = () => {
-      contentEl && (contentEl.innerText = (body?.value || ""));
-    };
-
-    const applyStyle = () => {
-      if (!card) return;
-      card.style.fontFamily = (fontSel?.value?.trim() || FALLBACK.font);
-      card.style.color      = (textInp?.value?.trim() || FALLBACK.text);
-      card.style.background = (bgInp?.value?.trim()   || FALLBACK.bg);
-
-      // バッジのHEX表示も更新（任意）
-      form.querySelectorAll('[data-colorpicker]').forEach((picker) => {
-        const k = picker.dataset.colorpicker;
-        const src = (k === "textColor") ? textInp : bgInp;
-        const val = (src?.value || "").trim();
-        const badge = picker.parentElement?.querySelector(".badge");
-        if (badge) badge.textContent = (val || (k === "textColor" ? FALLBACK.text : FALLBACK.bg)).toUpperCase();
-      });
-    };
-
-    // picker ⇄ text 双方向バインド（input + change 両方で安定）
-    const bindPair = (textInput, pickerInput) => {
-      if (!textInput || !pickerInput) return;
-      const fromPicker = (e) => { textInput.value = e.target.value; applyStyle(); };
-      pickerInput.addEventListener("input",  fromPicker);
-      pickerInput.addEventListener("change", fromPicker);
-      textInput.addEventListener("input", (e) => {
-        const v = e.target.value;
-        if (/^#(?:[0-9a-fA-F]{3}){1,2}$/.test(v)) pickerInput.value = v;
-        applyStyle();
-      });
-    };
-
-    // イベント
-    [title, author].forEach(el => el && el.addEventListener("input", updateMeta));
-    body && body.addEventListener("input", updateBody);
-    fontSel && fontSel.addEventListener("change", applyStyle);
-    bindPair(textInp, textPicker);
-    bindPair(bgInp,   bgPicker);
-
-    // 初期反映（ここ超重要）
-    updateMeta(); updateBody(); applyStyle();
+  const anyCard = cardD || cardM;
+  const FALLBACK = {
+    font: anyCard?.style.fontFamily || "var(--font-serif)",
+    text: anyCard?.style.color      || "#111827",
+    bg:   anyCard?.style.background || "#F9FAFB"
   };
 
-  // Turbo対策：キャッシュ復帰も拾う
-  if (window.Turbo) {
-    document.addEventListener("turbo:load", run);
-    document.addEventListener("turbo:render", run);
-  } else {
-    // 非Turboでも動くように
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", run);
-    } else {
-      run();
+  function setCardStyle(el){
+    if (!el) return;
+    el.style.fontFamily = (fontSel?.value?.trim() || FALLBACK.font);
+    el.style.color      = (textInp?.value?.trim() || FALLBACK.text);
+    el.style.background = (bgInp?.value?.trim()   || FALLBACK.bg);
+  }
+
+  function updateMeta(){
+    const a = (author?.value || "").trim();
+    const t = (title?.value  || "").trim();
+    const meta = [a, t ? `『${t}』` : null].filter(Boolean).join(" ");
+    if (metaD) metaD.textContent = meta;
+    if (metaM) metaM.textContent = meta;
+  }
+
+  function updateBody(){
+    const v = (body?.value || "");
+    if (contD) contD.textContent = v;
+    if (contM) contM.textContent = v;
+  }
+
+  function applyStyleBoth(){
+    setCardStyle(cardD);
+    setCardStyle(cardM);
+  }
+
+  // ピッカー <-> テキスト 双方向同期
+  function bindPair(textInput, colorInput){
+    if (!textInput || !colorInput) return;
+    colorInput.addEventListener("input", e => {
+      textInput.value = e.target.value;
+      applyStyleBoth();
+    });
+    textInput.addEventListener("input", e => {
+      if (/^#/.test(e.target.value)) colorInput.value = e.target.value;
+      applyStyleBoth();
+    });
+  }
+
+  // クイックフォント
+  form.querySelectorAll('[data-quick-font]').forEach(btn => {
+    btn.addEventListener("click", () => {
+      if (!fontSel) return;
+      fontSel.value = btn.dataset.quickFont;
+      fontSel.dispatchEvent(new Event("change"));
+    });
+  });
+
+  // プリセット色・未指定・現在色
+  function rgbToHex(rgb) {
+    const m = rgb.match(/\d+/g);
+    if (!m) return "";
+    return "#" + m.slice(0, 3).map(n => ("0" + parseInt(n, 10).toString(16)).slice(-2)).join("");
+  }
+
+  function saveRecent(inputEl, hex) {
+    if (!hex || !hex.startsWith("#")) return;
+    const key = inputEl === textInp ? "recent_text" : "recent_bg";
+    const arr = JSON.parse(localStorage.getItem(key) || "[]").filter(v => v !== hex);
+    arr.unshift(hex);
+    localStorage.setItem(key, JSON.stringify(arr.slice(0, 8)));
+    renderRecent();
+  }
+
+  function renderRecent() {
+    const wrapText = form.querySelector('[data-recent="textColor"]');
+    const wrapBg   = form.querySelector('[data-recent="bgColor"]');
+
+    const make = (hex, key) => {
+      const b = document.createElement("button");
+      b.type = "button"; b.title = hex;
+      b.className = "size-6 rounded-full border";
+      b.style.background = hex;
+      b.dataset.colorPreset = key;
+      b.dataset.value = hex;
+      b.addEventListener("click", () => {
+        const text = key === "textColor" ? textInp : bgInp;
+        const pick = key === "textColor" ? textPick : bgPick;
+        if (text) text.value = hex;
+        if (pick) pick.value = hex;
+        applyStyleBoth(); saveRecent(text, hex);
+      });
+      return b;
+    };
+
+    if (wrapText) {
+      wrapText.innerHTML = "";
+      (JSON.parse(localStorage.getItem("recent_text") || "[]"))
+        .forEach(hex => wrapText.appendChild(make(hex, "textColor")));
     }
+    if (wrapBg) {
+      wrapBg.innerHTML = "";
+      (JSON.parse(localStorage.getItem("recent_bg") || "[]"))
+        .forEach(hex => wrapBg.appendChild(make(hex, "bgColor")));
+    }
+  }
+
+  form.querySelectorAll('[data-color-preset]').forEach(btn => {
+    btn.addEventListener("click", (e) => {
+      const key = e.currentTarget.dataset.colorPreset;
+      const val = e.currentTarget.dataset.value;
+      const text = key === "textColor" ? textInp : bgInp;
+      const pick = key === "textColor" ? textPick : bgPick;
+      if (text) text.value = val;
+      if (pick) pick.value = val;
+      applyStyleBoth(); saveRecent(text, val);
+    });
+  });
+  form.querySelectorAll('[data-clear-color]').forEach(btn => {
+    btn.addEventListener("click", (e) => {
+      const key = e.currentTarget.dataset.clearColor;
+      const text = key === "textColor" ? textInp : bgInp;
+      if (text) text.value = "";
+      applyStyleBoth();
+    });
+  });
+  form.querySelectorAll('[data-pick-current]').forEach(btn => {
+    btn.addEventListener("click", (e) => {
+      const key = e.currentTarget.dataset.pickCurrent;
+      const text = key === "textColor" ? textInp : bgInp;
+      const prop = key === "textColor" ? "color" : "backgroundColor";
+      const val = (cardD || cardM) ? rgbToHex(getComputedStyle(cardD || cardM)[prop]) : "";
+      if (text && val) text.value = val;
+      const pick = key === "textColor" ? textPick : bgPick;
+      if (pick) pick.value = val;
+      applyStyleBoth(); saveRecent(text, val);
+    });
+  });
+
+  // イベント
+  [title, author].forEach(el => el && el.addEventListener("input", updateMeta));
+  body && body.addEventListener("input", updateBody);
+  fontSel && fontSel.addEventListener("change", applyStyleBoth);
+  bindPair(textInp, textPick);
+  bindPair(bgInp, bgPick);
+
+  // 初期反映
+  updateMeta(); updateBody(); applyStyleBoth(); renderRecent();
+
+  // モバイル：展開/収納（任意）
+  const toggleBtn = document.getElementById('toggle-mobile-preview');
+  if (toggleBtn && cardM){
+    let expanded = true;
+    toggleBtn.addEventListener('click', () => {
+      expanded = !expanded;
+      cardM.style.maxHeight = expanded ? '28vh' : '10vh';
+      cardM.style.overflow  = 'auto';
+    });
   }
 })();
 </script>

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -16,7 +16,7 @@
        font: @passage.customization&.font.presence     || @passage.font_family.presence || "var(--font-serif)"
      } %>
 
-  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden">
+  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-visible md:overflow-visible">
     <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
 
     <div class="grid gap-6 md:grid-cols-2 items-start">

--- a/app/views/thought_logs/new.html.erb
+++ b/app/views/thought_logs/new.html.erb
@@ -8,7 +8,7 @@
     <%= link_to "← 戻る", passage_path(@passage), class: "link link-primary" %>
   </div>
 
-  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden">
+  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-visible md:overflow-visible">
     <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full
                 bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
 


### PR DESCRIPTION
## 概要
- プレビュー変数 (style_bg, style_text, style_font) の定義位置を整理
  - フォームの中で二重に定義されていたものを削除
  - 部分テンプレートの先頭で一度だけ定義し、フォーム内・モバイルプレビューの両方で共通利用できるように修正
- これにより NameError (undefined local variable or method) の解消
- PC 版は sticky プレビュー、スマホ版は下部固定プレビューで正しく初期値が反映されるようにしました。

## 変更点
- _form.html.erb
  - 変数 style_bg / style_text / style_font を先頭で定義
  - 右カラム直前での再定義を削除
  - モバイルプレビューでも同じ変数を参照するように変更

## 対応issue
close #36