### PR TITLE
renderエラーの修正

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -1,6 +1,13 @@
 set -o errexit
 
-bundle install
+# 依存入れる
+bundle config set without 'development test'
+bundle install -j4 --retry 3
+
+# （使っていれば）フロントのビルド
+yarn install --frozen-lockfile || true
+yarn build || true
+
+# Rails アセット
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
-bundle exec rails db:migrate

--- a/bin/render-start.sh
+++ b/bin/render-start.sh
@@ -1,0 +1,7 @@
+set -e
+
+echo "==> Running db:migrate..."
+bundle exec rails db:migrate
+
+echo "==> Starting Puma..."
+exec bundle exec puma -C config/puma.rb


### PR DESCRIPTION
## 概要
- Render 環境でのデプロイ安定化のため、起動スクリプトを追加しました。
- アプリ起動前に db:migrate を自動実行し、その後 Puma を起動するようにしています。

## 変更内容
- bin/render-start.sh を追加
  - bundle exec rails db:migrate を実行
  - puma を config/puma.rb の設定で起動
- chmod +x を付与し、実行可能に設定
- Render の Start Command を ./bin/render-start.sh に切り替え

 ## 目的
- デプロイ時に自動でマイグレーションを走らせ、手動作業を削減
- Render の標準ポート設定 (port ENV.fetch("PORT") { 3000 }) に対応
- Puma を正式に Render 環境で運用するための準備