### PR TITLE
BookInfoモデルの作成

### DIFF
--- a/app/models/book_info.rb
+++ b/app/models/book_info.rb
@@ -1,0 +1,3 @@
+class BookInfo < ApplicationRecord
+  belongs_to :passage
+end

--- a/db/migrate/20250905074633_create_book_infos.rb
+++ b/db/migrate/20250905074633_create_book_infos.rb
@@ -1,0 +1,13 @@
+class CreateBookInfos < ActiveRecord::Migration[7.2]
+  def change
+    create_table :book_infos do |t|
+      t.references :passage, null: false, foreign_key: true
+      t.string :title
+      t.string :author
+      t.date :published_date
+      t.string :isbn
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_01_062309) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_05_074633) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "book_infos", force: :cascade do |t|
+    t.bigint "passage_id", null: false
+    t.string "title"
+    t.string "author"
+    t.date "published_date"
+    t.string "isbn"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["passage_id"], name: "index_book_infos_on_passage_id"
+  end
 
   create_table "passage_customizations", force: :cascade do |t|
     t.string "font"
@@ -65,6 +76,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_01_062309) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "book_infos", "passages"
   add_foreign_key "passage_customizations", "passages"
   add_foreign_key "passage_customizations", "users"
   add_foreign_key "passages", "users"

--- a/test/fixtures/book_infos.yml
+++ b/test/fixtures/book_infos.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  passage: one
+  title: MyString
+  author: MyString
+  published_date: 2025-09-05
+  isbn: MyString
+
+two:
+  passage: two
+  title: MyString
+  author: MyString
+  published_date: 2025-09-05
+  isbn: MyString

--- a/test/models/book_info_test.rb
+++ b/test/models/book_info_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BookInfoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- 書籍情報を保持する BookInfo モデルを新規作成。
- 各 Passage と関連付けて、タイトル・著者・出版日・ISBN を保存できるようにしました。

## 変更内容
- BookInfo モデルの作成
  - カラム: title:string, author:string, published_date:date, isbn:string
  - passage:references を追加し Passage と関連付け
- マイグレーションを実行しテーブルを作成
- BookInfo モデルに belongs_to :passage を追加

## 対応issue
close #37