### PR TITLE
BookInfo の関連付けと最小表示

### DIFF
--- a/app/controllers/book_infos_controller.rb
+++ b/app/controllers/book_infos_controller.rb
@@ -1,0 +1,13 @@
+class BookInfosController < ApplicationController
+  def search
+    if params[:q].present?
+      @results = BookLookups::FetchBookInfo.by_title_author(title: params[:q], author: nil)
+    else
+      @results = []
+    end
+  rescue => e
+    Rails.logger.error(e)
+    @results = []
+    flash.now[:alert] = "検索中にエラーが発生しました"
+  end
+end

--- a/app/controllers/passages_controller.rb
+++ b/app/controllers/passages_controller.rb
@@ -9,8 +9,14 @@ class PassagesController < ApplicationController
   end
 
   def create
-    normalize_customization_key!
-    @passage = current_user.passages.new(passage_params)
+    normalize_nested_keys!
+
+    # update_only 対策：未作成で attrs が来たら build
+    @passage = current_user.passages.new
+    @passage.build_customization(user: current_user) if @passage.customization.nil? && params.dig(:passage, :customization_attributes).present?
+    @passage.build_book_info                         if @passage.book_info.nil?       && params.dig(:passage, :book_info_attributes).present?
+
+    @passage.assign_attributes(passage_params)
     @passage.customization&.user ||= current_user
 
     if @passage.save
@@ -35,19 +41,26 @@ class PassagesController < ApplicationController
   end
 
   def update
-    normalize_customization_key!
+  # ここを変更
+  normalize_nested_keys!
 
-    if @passage.customization.nil? && params.dig(:passage, :customization_attributes).present?
-      @passage.build_customization(user: current_user)
-    end
-
-    if @passage.update(passage_params)
-      redirect_to @passage, notice: "カードを更新したよ。"
-    else
-      flash.now[:alert] = "更新に失敗しちゃった…入力を見直してね。"
-      render :edit, status: :unprocessable_entity
-    end
+  # customization が未作成なら先に build
+  if @passage.customization.nil? && params.dig(:passage, :customization_attributes).present?
+    @passage.build_customization(user: current_user)
   end
+
+  # book_info が未作成なら先に build  ← 追加
+  if @passage.book_info.nil? && params.dig(:passage, :book_info_attributes).present?
+    @passage.build_book_info
+  end
+
+  if @passage.update(passage_params)
+    redirect_to @passage, notice: "カードを更新したよ。"
+  else
+    flash.now[:alert] = "更新に失敗しちゃった…入力を見直してね。"
+    render :edit, status: :unprocessable_entity
+  end
+end
 
   def destroy
     if @passage.destroy
@@ -69,16 +82,22 @@ class PassagesController < ApplicationController
   end
 
   # passage[customization] で来ても受けられるように変換
-  def normalize_customization_key!
-    c = params.dig(:passage, :customization)
-    params[:passage][:customization_attributes] ||= c if c
+  def normalize_nested_keys!
+    if (c = params.dig(:passage, :customization)).present? && params.dig(:passage, :customization_attributes).blank?
+      params[:passage][:customization_attributes] = c
+    end
+    if (b = params.dig(:passage, :book_info)).present? && params.dig(:passage, :book_info_attributes).blank?
+      params[:passage][:book_info_attributes] = b
+    end
   end
 
   def passage_params
     params.require(:passage).permit(
       :content, :title, :author,
       :bg_color, :text_color, :font_family,
-      customization_attributes: [ :id, :font, :color, :bg_color ]
+      customization_attributes: [ :id, :font, :color, :bg_color ],
+      # ← MVP最小（いまのスキーマに合わせる）
+      book_info_attributes: [ :id, :title, :author, :published_date, :isbn ]
     )
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,0 @@
-class PostsController < ApplicationController
-  def index
-  end
-end

--- a/app/helpers/book_infos_helper.rb
+++ b/app/helpers/book_infos_helper.rb
@@ -1,0 +1,2 @@
+module BookInfosHelper
+end

--- a/app/models/book_info.rb
+++ b/app/models/book_info.rb
@@ -1,3 +1,7 @@
 class BookInfo < ApplicationRecord
-  belongs_to :passage
+  belongs_to :passage, inverse_of: :book_info
+
+  validates :title, length: { maximum: 255 }, allow_blank: true
+  validates :author, length: { maximum: 255 }, allow_blank: true
+  validates :isbn, length: { maximum: 32 }, allow_blank: true
 end

--- a/app/models/passage.rb
+++ b/app/models/passage.rb
@@ -1,22 +1,23 @@
 class Passage < ApplicationRecord
-  # 所有者
   belongs_to :user
 
-  # 関連
+  has_one  :book_info,
+           dependent: :destroy,
+           inverse_of: :passage
+
   has_many :thought_logs, dependent: :destroy
+
   has_one  :customization,
            class_name: "PassageCustomization",
            dependent: :destroy,
            inverse_of: :passage
 
-  # 作成/編集フォームでカスタマイズを一緒に受け取る
   accepts_nested_attributes_for :customization, update_only: true
+  accepts_nested_attributes_for :book_info,     update_only: true
 
-  # バリデーション
   validates :content, presence: true, length: { maximum: 2000 }
   validates :title,   length: { maximum: 200 },  allow_blank: true
   validates :author,  length: { maximum: 120 },  allow_blank: true
 
-  # 旧カラム（段階移行中なら残す）
   validates :bg_color, :text_color, :font_family, length: { maximum: 50 }, allow_blank: true
 end

--- a/app/views/book_infos/search.html.erb
+++ b/app/views/book_infos/search.html.erb
@@ -1,0 +1,34 @@
+<div class="max-w-md mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-4">📚 書籍を検索</h1>
+
+  <%= form_with url: search_book_infos_path, method: :get, local: true, class: "space-y-4" do |f| %>
+    <div>
+      <%= f.label :q, "タイトルやキーワード", class: "block font-semibold mb-1" %>
+      <%= f.text_field :q, value: params[:q], class: "input input-bordered w-full" %>
+    </div>
+    <%= f.submit "検索する", class: "btn btn-primary w-full" %>
+  <% end %>
+
+  <% if params[:q].present? %>
+    <div class="mt-6">
+      <h2 class="text-lg font-semibold mb-2">検索結果</h2>
+
+      <% if @results.any? %>
+        <ul class="space-y-4">
+          <% @results.each do |book| %>
+            <li class="p-4 border rounded-lg">
+              <div class="font-bold"><%= book[:title] %></div>
+              <div class="text-sm opacity-70"><%= book[:authors]&.join(", ") %></div>
+              <div class="text-xs opacity-60"><%= book[:published_date] %></div>
+              <% if book[:cover_url].present? %>
+                <img src="<%= book[:cover_url] %>" alt="<%= book[:title] %>" class="mt-2 w-24" />
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-sm opacity-70">該当する書籍が見つかりませんでした。</p>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/passages/_form.html.erb
+++ b/app/views/passages/_form.html.erb
@@ -2,7 +2,6 @@
 <% style_text = passage.customization&.color.presence      || passage.text_color.presence  || "#111827" %>
 <% style_font = passage.customization&.font.presence       || passage.font_family.presence || "var(--font-serif)" %>
 
-
 <%= form_with model: passage,
               local: true,
               html: { id: "passage-form", autocomplete: "off" },
@@ -165,7 +164,6 @@
     </div>
 
     <%# ================= 右：PC用 sticky プレビュー ================= %>
-
     <div class="hidden md:block md:sticky md:top-24">
       <div class="mb-2">
         <h2 class="text-xl font-bold gh-underline">プレビュー</h2>
@@ -235,16 +233,16 @@
 
   const anyCard = cardD || cardM;
   const FALLBACK = {
-    font: anyCard?.style.fontFamily || "var(--font-serif)",
-    text: anyCard?.style.color      || "#111827",
-    bg:   anyCard?.style.background || "#F9FAFB"
+    font: (anyCard && anyCard.style.fontFamily) || "var(--font-serif)",
+    text: (anyCard && anyCard.style.color)      || "#111827",
+    bg:   (anyCard && anyCard.style.background) || "#F9FAFB"
   };
 
   function setCardStyle(el){
     if (!el) return;
-    el.style.fontFamily = (fontSel?.value?.trim() || FALLBACK.font);
-    el.style.color      = (textInp?.value?.trim() || FALLBACK.text);
-    el.style.background = (bgInp?.value?.trim()   || FALLBACK.bg);
+    el.style.fontFamily = (fontSel && fontSel.value.trim()) || FALLBACK.font;
+    el.style.color      = (textInp && textInp.value.trim()) || FALLBACK.text;
+    el.style.background = (bgInp   && bgInp.value.trim())   || FALLBACK.bg;
   }
 
   function updateMeta(){
@@ -288,7 +286,7 @@
     });
   });
 
-  // プリセット色・未指定・現在色
+  // 最近色ユーティリティ
   function rgbToHex(rgb) {
     const m = rgb.match(/\d+/g);
     if (!m) return "";
@@ -337,6 +335,7 @@
     }
   }
 
+  // プリセット/未指定/現在色
   form.querySelectorAll('[data-color-preset]').forEach(btn => {
     btn.addEventListener("click", (e) => {
       const key = e.currentTarget.dataset.colorPreset;
@@ -361,7 +360,8 @@
       const key = e.currentTarget.dataset.pickCurrent;
       const text = key === "textColor" ? textInp : bgInp;
       const prop = key === "textColor" ? "color" : "backgroundColor";
-      const val = (cardD || cardM) ? rgbToHex(getComputedStyle(cardD || cardM)[prop]) : "";
+      const source = cardD || cardM;
+      const val = source ? rgbToHex(getComputedStyle(source)[prop]) : "";
       if (text && val) text.value = val;
       const pick = key === "textColor" ? textPick : bgPick;
       if (pick) pick.value = val;
@@ -379,7 +379,7 @@
   // 初期反映
   updateMeta(); updateBody(); applyStyleBoth(); renderRecent();
 
-  // モバイル：展開/収納（任意）
+  // モバイル：展開/収納
   const toggleBtn = document.getElementById('toggle-mobile-preview');
   if (toggleBtn && cardM){
     let expanded = true;

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -79,6 +79,24 @@
           </dl>
         </div>
 
+        <% if @passage.book_info.present? %>
+  <% b = @passage.book_info %>
+  <div class="mt-6 rounded-2xl gh-glass p-5">
+    <div class="flex gap-3 items-start">
+      <% if b.cover_url.present? %>
+        <img src="<%= b.cover_url %>" alt="" class="w-16 h-24 object-cover rounded">
+      <% end %>
+      <div>
+        <div class="font-semibold"><%= b.title %></div>
+        <div class="opacity-70"><%= b.author %></div>
+        <div class="opacity-60 text-sm">
+          <%= [b.publisher, b.published_date, b.isbn].compact_blank.join(" / ") %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>
+
         <!-- 思考ログ：この一節に紐づく“考えの連鎖” -->
         <section class="mt-6">
           <div class="flex items-end justify-between">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,2 +1,0 @@
-<h1 class="text-4xl text-green-700 font-semibold underline">Hello,world</h1>
-<button class="btn btn-primary">Hello, daisyUI!</button>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,29 +2,31 @@ Rails.application.routes.draw do
   devise_for :users
 
   # ヘルス/PWA
-  get "up"                => "rails/health#show",  as: :rails_health_check
-  get "service-worker"    => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest"          => "rails/pwa#manifest", as: :pwa_manifest
+  get "up"             => "rails/health#show",  as: :rails_health_check
+  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
+  get "manifest"       => "rails/pwa#manifest", as: :pwa_manifest
 
   # 画面
   root "top#index"
   get "dashboard", to: "dashboard#index"
   get "profile",   to: "users#show", as: :profile
 
-  # 書籍ルックアップ（今回の主役）
-  get "books/lookup", to: "books#lookup"
-  # テストが参照している posts_index_url を復活
-  get "posts/index", to: "posts#index", as: :posts_index
+  # 書籍検索フォーム画面
+  resources :book_infos, only: [] do
+    collection do
+      get :search
+    end
+  end
+
+  # API (残しておく)
+  namespace :api do
+    resources :books, only: [ :index ]
+  end
 
   # passages
   resources :passages, only: [ :new, :create, :show, :edit, :update, :destroy ] do
     resources :thought_logs, only: [ :new, :create ]
     resource  :customization, only: [ :new, :create, :edit, :update ],
               controller: "passage_customizations"
-  end
-
-  # （任意）API用エンドポイントも残すなら
-  namespace :api do
-    resources :books, only: [ :index ]  # /api/books?isbn=... or &title=...
   end
 end

--- a/db/migrate/20250907112927_add_details_to_book_infos.rb
+++ b/db/migrate/20250907112927_add_details_to_book_infos.rb
@@ -1,0 +1,9 @@
+class AddDetailsToBookInfos < ActiveRecord::Migration[7.2]
+  def change
+    add_column :book_infos, :cover_url, :string
+    add_column :book_infos, :source, :string
+    add_column :book_infos, :source_id, :string
+    add_column :book_infos, :page_count, :integer
+    add_column :book_infos, :publisher, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_05_074633) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_07_112927) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_05_074633) do
     t.string "isbn"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "cover_url"
+    t.string "source"
+    t.string "source_id"
+    t.integer "page_count"
+    t.string "publisher"
     t.index ["passage_id"], name: "index_book_infos_on_passage_id"
   end
 

--- a/test/controllers/book_infos_controller_test.rb
+++ b/test/controllers/book_infos_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BookInfosControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class PostsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get posts_index_url
-    assert_response :success
-  end
-end


### PR DESCRIPTION
## 概要
- 一節（Passage）に紐づく書籍情報（BookInfo）を保存・参照できる土台を追加。
- 詳細ページ（/passages/:id）で BookInfo の基本情報を表示。
- 書籍検索/自動入力のUI・API連携は 次ブランチ で実装。

## 変更内容
- Model
  - Passage に belongs_to :book_info, optional: true
  - BookInfo に belongs_to :passage, inverse_of: :book_info
  - Passage に accepts_nested_attributes_for :book_info, update_only: true
- Controller
  - PassagesController
    - Strong Params に book_info_attributes を追加（title, author, published_date, isbn, cover_url, source, source_id,         publisher, page_count）
    - create/update でネストキーの正規化（normalize_nested_keys!）
    - update_only対策として未作成時に build_book_info/build_customization
- View
  - passages/show.html.erb に BookInfo 表示ブロック（タイトル/著者/出版社/出版日/ISBN/カバー画像）
- Migration（既存）
  - book_infos（passage:references, title, author, published_date:date, isbn）を前提に利用

## 対応issue
close #39