### PR TITLE
モデル整備

### DIFF
--- a/app/controllers/thought_logs_controller.rb
+++ b/app/controllers/thought_logs_controller.rb
@@ -7,9 +7,9 @@ class ThoughtLogsController < ApplicationController
   end
 
   def create
-    @thought_log = @passage.thought_logs.new(thought_log_params)
+    @thought_log = @passage.thought_logs.build(thought_log_params.merge(user: current_user))
     if @thought_log.save
-      redirect_to passage_path(@passage), notice: "思考ログを保存したよ。"
+      redirect_to @passage, notice: "思考ログを保存したよ。"
     else
       flash.now[:alert] = "保存に失敗しちゃった…入力を見直してね。"
       render :new, status: :unprocessable_entity
@@ -19,7 +19,9 @@ class ThoughtLogsController < ApplicationController
   private
 
   def set_passage
-    @passage = Passage.find(params[:passage_id])
+    @passage = current_user.passages.find(params[:passage_id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to dashboard_path, alert: "このカードは見つからないか、あなたのものではありません。"
   end
 
   def thought_log_params

--- a/app/models/thought_log.rb
+++ b/app/models/thought_log.rb
@@ -1,5 +1,6 @@
 class ThoughtLog < ApplicationRecord
   belongs_to :passage
+  belongs_to :user
 
   validates :content, presence: true, length: { maximum: 10_000 }
 end

--- a/db/migrate/20250911081647_make_book_infos_one_to_one.rb
+++ b/db/migrate/20250911081647_make_book_infos_one_to_one.rb
@@ -1,0 +1,6 @@
+class MakeBookInfosOneToOne < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :book_infos, :passage_id if index_exists?(:book_infos, :passage_id, unique: false)
+    add_index    :book_infos, :passage_id, unique: true unless index_exists?(:book_infos, :passage_id, unique: true)
+  end
+end

--- a/db/migrate/20250911081759_tighten_passages.rb
+++ b/db/migrate/20250911081759_tighten_passages.rb
@@ -1,0 +1,6 @@
+class TightenPassages < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :passages, :user_id, false
+    add_index :passages, [ :user_id, :created_at ] unless index_exists?(:passages, [ :user_id, :created_at ])
+  end
+end

--- a/db/migrate/20250911081828_add_user_to_thought_logs.rb
+++ b/db/migrate/20250911081828_add_user_to_thought_logs.rb
@@ -1,0 +1,18 @@
+class AddUserToThoughtLogs < ActiveRecord::Migration[7.2]
+  def up
+    add_reference :thought_logs, :user, foreign_key: true, null: true
+
+    execute <<~SQL
+      UPDATE thought_logs tl
+      SET user_id = p.user_id
+      FROM passages p
+      WHERE tl.passage_id = p.id AND tl.user_id IS NULL;
+    SQL
+
+    change_column_null :thought_logs, :user_id, false
+  end
+
+  def down
+    remove_reference :thought_logs, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_11_053336) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_11_081828) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_053336) do
     t.string "source_id"
     t.integer "page_count"
     t.string "publisher"
-    t.index ["passage_id"], name: "index_book_infos_on_passage_id"
+    t.index ["passage_id"], name: "index_book_infos_on_passage_id", unique: true
   end
 
   create_table "passage_customizations", force: :cascade do |t|
@@ -50,8 +50,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_053336) do
     t.string "bg_color"
     t.string "text_color"
     t.string "font_family"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.text "content"
+    t.index ["user_id", "created_at"], name: "index_passages_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_passages_on_user_id"
   end
 
@@ -60,7 +61,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_053336) do
     t.bigint "passage_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["passage_id"], name: "index_thought_logs_on_passage_id"
+    t.index ["user_id"], name: "index_thought_logs_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -87,4 +90,5 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_11_053336) do
   add_foreign_key "passage_customizations", "users"
   add_foreign_key "passages", "users"
   add_foreign_key "thought_logs", "passages"
+  add_foreign_key "thought_logs", "users"
 end

--- a/test/controllers/thought_logs_controller_test.rb
+++ b/test/controllers/thought_logs_controller_test.rb
@@ -2,10 +2,10 @@ require "test_helper"
 
 class ThoughtLogsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:one) # fixturesを使ってるならここを調整
-    sign_in @user
-    @passage = passages(:one) # fixturesのPassage
-  end
+  @user = users(:alice)
+  sign_in @user
+  @passage = passages(:one) # passages(:one) は fixtures で user: alice なので整合OK
+end
 
   test "should get new" do
     get new_passage_thought_log_url(@passage)

--- a/test/fixtures/passage_customizations.yml
+++ b/test/fixtures/passage_customizations.yml
@@ -1,15 +1,13 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
-  font: MyString
-  color: MyString
-  bg_color: MyString
   passage: one
-  user: one
+  user: alice
+  font: "var(--font-serif)"
+  color: "#111827"
+  bg_color: "#F9FAFB"
 
 two:
-  font: MyString
-  color: MyString
-  bg_color: MyString
   passage: two
-  user: two
+  user: bob
+  font: "var(--font-sans)"
+  color: "#111827"
+  bg_color: "#F3F4F6"

--- a/test/fixtures/passages.yml
+++ b/test/fixtures/passages.yml
@@ -1,11 +1,15 @@
 one:
-  content: "fixtureで登録したテストの一節"
-  title: "テストタイトル"
-  author: "テスト著者"
-  user: one
+  user: alice
+  title: "サンプルの一節"
+  author: "作者A"
+  content: "本文A"
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
 
 two:
-  content: "もう一つの一節"
-  title: "別のタイトル"
-  author: "誰か"
-  user: one
+  user: bob
+  title: "別サンプル"
+  author: "作者B"
+  content: "本文B"
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/test/fixtures/thought_logs.yml
+++ b/test/fixtures/thought_logs.yml
@@ -1,9 +1,13 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 one:
-  content: MyText
   passage: one
+  user: alice
+  content: "MyText"
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>
 
 two:
-  content: MyText
   passage: two
+  user: bob
+  content: "Another memo"
+  created_at: <%= Time.current %>
+  updated_at: <%= Time.current %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,9 @@
-one:
-  email: user1@example.com
-  encrypted_password: <%= Devise::Encryptor.digest(User, 'password123') %>
-  # Confirmable を有効にしているなら ↓ を追加
-  # confirmed_at: <%= Time.current %>
+alice:
+  email: alice@example.com
+  name: Alice
+  confirmed_at: <%= Time.current %>
 
-two:
-  email: user2@example.com
-  encrypted_password: <%= Devise::Encryptor.digest(User, 'password123') %>
+bob:
+  email: bob@example.com
+  name: Bob
+  confirmed_at: <%= Time.current %>


### PR DESCRIPTION
## 概要
- データ整合性と参照性を高め、将来の機能追加（思考ログのユーザー軸集計など）に備えるため、RDB の制約を強化しました。
- アプリ側での想定（Passage は必ず User 所有／BookInfo は Passage と1対1／ThoughtLog は Passage と User に属す）をDB制約で担保します。

## 変更点

1. book_infos を Passage と 1:1 に固定
- 既存の index_book_infos_on_passage_id を unique に変更（重複防止）
2. passages.user_id を NOT NULL に
- 取得時のパフォーマンス向上のため [:user_id, :created_at] 複合 index 追加
3. thought_logs に user_id を追加（FK: users）し NOT NULL に
- 既存データは passages.user_id で 安全にバックフィル してから NOT NULL 化