### PR TITLE
カスタマイズ画面のカラーパレット実装

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,3 @@
-// Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./preview_card"

--- a/app/javascript/controllers/color_picker_controller.js
+++ b/app/javascript/controllers/color_picker_controller.js
@@ -1,0 +1,83 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = { key: String }; // "text" / "bg" など
+  static targets = ["field", "native", "badge", "recent"];
+
+  connect() {
+    this.recentStorageKey = `qc:recent_colors:${this.keyValue || "default"}`;
+    this.syncFromField();
+    this.renderRecent();
+  }
+
+  // プリセット丸クリック
+  pick({ params }) {
+    this.apply(params.color, true);
+  }
+
+  // ネイティブの color input
+  choose(e) {
+    this.apply(e.target.value, true);
+  }
+
+  // 手入力（テキストフィールド）
+  manual(e) {
+    this.apply(e.target.value, false);
+  }
+
+  // 反映（入力2箇所 + バッジ + 変更イベント）
+  apply(color, pushRecent) {
+    const hex = this.normalize(color);
+    if (!hex) return;
+
+    this.setValue(this.fieldTarget, hex);
+    this.setValue(this.nativeTarget, hex);
+
+    if (this.hasBadgeTarget) this.badgeTarget.textContent = hex.toUpperCase();
+
+    // プレビュー等に拾わせる
+    this.fieldTarget.dispatchEvent(new Event("input",  { bubbles: true }));
+    this.fieldTarget.dispatchEvent(new Event("change", { bubbles: true }));
+
+    if (pushRecent) this.pushRecent(hex);
+  }
+
+  // ========= utils =========
+  setValue(el, val) { if (el && el.value !== val) el.value = val; }
+
+  normalize(s) {
+    if (!s) return null;
+    let x = String(s).trim();
+    if (!x.startsWith("#")) x = `#${x}`;
+    x = x.toUpperCase();
+    return /^#([0-9A-F]{3}|[0-9A-F]{6})$/.test(x) ? x : null;
+  }
+
+  syncFromField() {
+    const v = this.fieldTarget?.value || this.nativeTarget?.value || "";
+    if (v) this.apply(v, false);
+  }
+
+  pushRecent(hex) {
+    let arr = [];
+    try { arr = JSON.parse(localStorage.getItem(this.recentStorageKey) || "[]"); } catch { /* noop */ }
+    arr = [hex, ...arr.filter(c => c !== hex)].slice(0, 6);
+    localStorage.setItem(this.recentStorageKey, JSON.stringify(arr));
+    this.renderRecent(arr);
+  }
+
+  renderRecent(arr = null) {
+    if (!this.hasRecentTarget) return;
+    if (!arr) {
+      try { arr = JSON.parse(localStorage.getItem(this.recentStorageKey) || "[]"); } catch { arr = []; }
+    }
+    this.recentTarget.innerHTML = arr.map(c => `
+      <button type="button"
+              class="size-6 rounded-full border"
+              style="background:${c}"
+              title="${c}"
+              data-action="click->color-picker#pick"
+              data-color-picker-color-param="${c}"></button>
+    `).join("");
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,16 +1,18 @@
-import { application } from "./application"
+import { application } from "./application";
 
-import BookSearchController from "./book_search_controller"
-application.register("book-search", BookSearchController)
+import BookSearchController  from "./book_search_controller";
+import OnboardingController  from "./onboarding_controller";
+import ColorPickerController from "./color_picker_controller";
+import HelloController       from "./hello_controller";
+import LashController        from "./lash_controller";
+import WelcomeController     from "./welcome_controller";
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+application.register("book-search",  BookSearchController);
+application.register("onboarding",   OnboardingController);
+application.register("color-picker",  ColorPickerController);
+application.register("hello",        HelloController);
+application.register("lash",         LashController);
+application.register("welcome",      WelcomeController);
 
-import LashController from "./lash_controller"
-application.register("lash", LashController)
-
-import WelcomeController from "./welcome_controller"
-application.register("welcome", WelcomeController)
-
-import OnboardingController from "./onboarding_controller";
-application.register("onboarding", OnboardingController);
+// 余計な Application.start() や window.Stimulus の代入は不要
+export {};

--- a/app/views/passage_customizations/_form.html.erb
+++ b/app/views/passage_customizations/_form.html.erb
@@ -1,5 +1,3 @@
-<%# locals: customization:, passage:, url:, submit_label:, fallback: { bg:, text:, font: } %>
-
 <%= form_with model: customization,
               url: url,
               local: true,
@@ -20,7 +18,7 @@
   <% end %>
 
   <div class="grid gap-6 md:grid-cols-2 items-start">
-    <!-- ① SPではプレビュー先頭 / md以上は右側に固定 -->
+    <!-- ① プレビュー（SP先頭 / md以上は右固定） -->
     <div class="order-1 md:order-2 md:sticky md:top-24">
       <div id="preview-card"
            class="relative rounded-2xl p-6 border card-lift"
@@ -42,7 +40,7 @@
       </div>
     </div>
 
-    <!-- ② 入力（SPでは後ろ / md以上は左） -->
+    <!-- ② 入力（SP後ろ / md以上は左） -->
     <div class="order-2 md:order-1 space-y-5">
       <!-- フォント -->
       <div>
@@ -69,16 +67,16 @@
             f: f,
             field: :color,
             label: "文字色",
-            picker_key: "textColor",
-            default_color: customization.color.presence || fallback[:text] %>
+            key: "textColor",
+            default_color: (customization.color.presence || fallback[:text]) %>
 
       <!-- 背景色 -->
       <%= render "passage_customizations/color_field_with_palette",
             f: f,
             field: :bg_color,
             label: "背景色",
-            picker_key: "bgColor",
-            default_color: customization.bg_color.presence || fallback[:bg] %>
+            key: "bgColor",
+            default_color: (customization.bg_color.presence || fallback[:bg]) %>
 
       <div class="flex gap-2">
         <%= f.submit submit_label, class: "btn btn-primary" %>
@@ -95,17 +93,15 @@
   👁 プレビュー
 </button>
 
-<!-- ④ 最小JS：双方向バインド + 初期反映 + FAB表示制御 -->
+<!-- ④ 最小JS：プレビュー即時反映（Stimulus連携を前提に超軽量） -->
 <script>
 (() => {
-  const root = document.currentScript.closest(".rounded-3xl") || document;
-  const card = root.querySelector("#preview-card");
-  const fontSel = root.querySelector('[data-preview-target="font"]');
-  const textInp = root.querySelector('[data-preview-target="textColor"]');
-  const bgInp   = root.querySelector('[data-preview-target="bgColor"]');
-  const textPick= root.querySelector('input[data-colorpicker="textColor"]');
-  const bgPick  = root.querySelector('input[data-colorpicker="bgColor"]');
-  const fab     = root.querySelector("#jump-preview");
+  const root  = document.currentScript.closest("body") || document;
+  const card  = root.querySelector("#preview-card");
+  const font  = root.querySelector('[data-preview-target="font"]');
+  const textI = root.querySelector('[data-preview-target="textColor"]');
+  const bgI   = root.querySelector('[data-preview-target="bgColor"]');
+  const fab   = root.querySelector("#jump-preview");
 
   const FALLBACK = {
     font: card?.dataset.fallbackFont || "var(--font-serif)",
@@ -114,51 +110,40 @@
   };
 
   const apply = () => {
-    if (card) {
-      card.style.fontFamily = (fontSel?.value?.trim() || FALLBACK.font);
-      card.style.color      = (textInp?.value?.trim() || FALLBACK.text);
-      card.style.background = (bgInp  ?.value?.trim() || FALLBACK.bg);
-    }
-    // バッジ更新（パレット側で .badge を用意している場合）
-    root.querySelectorAll('[data-colorpicker]').forEach((picker) => {
-      const key = picker.dataset.colorpicker;
-      const src = key === "textColor" ? textInp : bgInp;
-      const val = (src?.value || "").trim();
-      const badge = picker.parentElement?.querySelector(".badge");
-      if (badge) badge.textContent = (val || (key === "textColor" ? FALLBACK.text : FALLBACK.bg)).toUpperCase();
-    });
+    if (!card) return;
+    card.style.fontFamily = (font?.value  || "").trim() || FALLBACK.font;
+    card.style.color      = (textI?.value || "").trim() || FALLBACK.text;
+    card.style.background = (bgI?.value   || "").trim() || FALLBACK.bg;
   };
 
-  const bindPair = (text, picker) => {
-    if (!text || !picker) return;
-    picker.addEventListener("input", e => { text.value = e.target.value; apply(); });
-    text.addEventListener("input",  e => { if (/^#(?:[0-9a-fA-F]{3}){1,2}$/.test(e.target.value)) picker.value = e.target.value; apply(); });
-  };
-
-  // クイックフォント
+  // フォント：クイックボタン
   root.querySelectorAll('[data-quick-font]').forEach(btn => {
     btn.addEventListener("click", () => {
-      if (!fontSel) return;
-      fontSel.value = btn.dataset.quickFont;
-      fontSel.dispatchEvent(new Event("change"));
+      if (!font) return;
+      font.value = btn.dataset.quickFont;
+      font.dispatchEvent(new Event("change", { bubbles: true }));
     });
   });
 
-  // FAB表示制御（プレビューが画面外に出たら表示）
+  // 入力の変化を監視（Stimulusが input/change を発火してくれる）
+  font?.addEventListener("change", apply);
+  textI?.addEventListener("input",  apply);
+  textI?.addEventListener("change", apply);
+  bgI?.addEventListener("input",    apply);
+  bgI?.addEventListener("change",   apply);
+
+  // 初期反映
+  apply();
+
+  // SP：プレビューが画面外に出たらFAB表示
   if (card && fab && "IntersectionObserver" in window) {
     const io = new IntersectionObserver(([ent]) => {
       fab.classList.toggle("hidden", ent.isIntersecting);
     }, { threshold: 0.1 });
     io.observe(card);
-
     fab.addEventListener("click", () => {
       card.scrollIntoView({ behavior: "smooth", block: "nearest" });
     });
   }
-
-  fontSel?.addEventListener("change", apply);
-  bindPair(textInp, textPick);
-  bindPair(bgInp,   bgPick);
-  apply(); // 初期反映
 })();
 </script>

--- a/app/views/passages/_form.html.erb
+++ b/app/views/passages/_form.html.erb
@@ -291,186 +291,183 @@
 <%# ================= プレビュー反映スクリプト（PC/モバイル対応） ================= %>
 <script>
 (function(){
-  const form = document.getElementById("passage-form") || document.querySelector("form");
-  if (!form) return;
+  function setupPreview(){
+    const form = document.getElementById("passage-form") || document.querySelector("form");
+    if (!form || form.dataset.previewBound === "1") return; // 二重バインド防止
+    form.dataset.previewBound = "1";
 
-  // 入力
-  const title  = form.querySelector('[data-preview-target="title"]');
-  const author = form.querySelector('[data-preview-target="author"]');
-  const body   = form.querySelector('[data-preview-target="content"]');
-  const fontSel= form.querySelector('[data-preview-target="font"]');
-  const textInp= form.querySelector('[data-preview-target="textColor"]');
-  const bgInp  = form.querySelector('[data-preview-target="bgColor"]');
-  const textPick = form.querySelector('input[data-colorpicker="textColor"]');
-  const bgPick   = form.querySelector('input[data-colorpicker="bgColor"]');
+    // === ここから下は元の処理をそのまま移植（内容は変えない） ===
 
-  // PC
-  const cardD = document.getElementById('preview-card-desktop');
-  const metaD = document.getElementById('preview-meta-desktop');
-  const contD = document.getElementById('preview-content-desktop');
+    // 入力
+    const title  = form.querySelector('[data-preview-target="title"]');
+    const author = form.querySelector('[data-preview-target="author"]');
+    const body   = form.querySelector('[data-preview-target="content"]');
+    const fontSel= form.querySelector('[data-preview-target="font"]');
+    const textInp= form.querySelector('[data-preview-target="textColor"]');
+    const bgInp  = form.querySelector('[data-preview-target="bgColor"]');
+    const textPick = form.querySelector('input[data-colorpicker="textColor"]');
+    const bgPick   = form.querySelector('input[data-colorpicker="bgColor"]');
 
-  // モバイル
-  const cardM = document.getElementById('preview-card-mobile');
-  const metaM = document.getElementById('preview-meta-mobile');
-  const contM = document.getElementById('preview-content-mobile');
+    // PC
+    const cardD = document.getElementById('preview-card-desktop');
+    const metaD = document.getElementById('preview-meta-desktop');
+    const contD = document.getElementById('preview-content-desktop');
 
-  const anyCard = cardD || cardM;
-  const FALLBACK = {
-    font: (anyCard && anyCard.style.fontFamily) || "var(--font-serif)",
-    text: (anyCard && anyCard.style.color)      || "#111827",
-    bg:   (anyCard && anyCard.style.background) || "#F9FAFB"
-  };
+    // モバイル
+    const cardM = document.getElementById('preview-card-mobile');
+    const metaM = document.getElementById('preview-meta-mobile');
+    const contM = document.getElementById('preview-content-mobile');
 
-  function setCardStyle(el){
-    if (!el) return;
-    el.style.fontFamily = (fontSel && fontSel.value.trim()) || FALLBACK.font;
-    el.style.color      = (textInp && textInp.value.trim()) || FALLBACK.text;
-    el.style.background = (bgInp   && bgInp.value.trim())   || FALLBACK.bg;
-  }
-
-  function updateMeta(){
-    const a = (author?.value || "").trim();
-    const t = (title?.value  || "").trim();
-    const meta = [a, t ? `『${t}』` : null].filter(Boolean).join(" ");
-    if (metaD) metaD.textContent = meta;
-    if (metaM) metaM.textContent = meta;
-  }
-
-  function updateBody(){
-    const v = (body?.value || "");
-    if (contD) contD.textContent = v;
-    if (contM) contM.textContent = v;
-  }
-
-  function applyStyleBoth(){
-    setCardStyle(cardD);
-    setCardStyle(cardM);
-  }
-
-  // ピッカー <-> テキスト 双方向同期
-  function bindPair(textInput, colorInput){
-    if (!textInput || !colorInput) return;
-    colorInput.addEventListener("input", e => {
-      textInput.value = e.target.value;
-      applyStyleBoth();
-    });
-    textInput.addEventListener("input", e => {
-      if (/^#/.test(e.target.value)) colorInput.value = e.target.value;
-      applyStyleBoth();
-    });
-  }
-
-  // クイックフォント
-  form.querySelectorAll('[data-quick-font]').forEach(btn => {
-    btn.addEventListener("click", () => {
-      if (!fontSel) return;
-      fontSel.value = btn.dataset.quickFont;
-      fontSel.dispatchEvent(new Event("change"));
-    });
-  });
-
-  // 最近色ユーティリティ
-  function rgbToHex(rgb) {
-    const m = rgb.match(/\d+/g);
-    if (!m) return "";
-    return "#" + m.slice(0, 3).map(n => ("0" + parseInt(n, 10).toString(16)).slice(-2)).join("");
-  }
-
-  function saveRecent(inputEl, hex) {
-    if (!hex || !hex.startsWith("#")) return;
-    const key = inputEl === textInp ? "recent_text" : "recent_bg";
-    const arr = JSON.parse(localStorage.getItem(key) || "[]").filter(v => v !== hex);
-    arr.unshift(hex);
-    localStorage.setItem(key, JSON.stringify(arr.slice(0, 8)));
-    renderRecent();
-  }
-
-  function renderRecent() {
-    const wrapText = form.querySelector('[data-recent="textColor"]');
-    const wrapBg   = form.querySelector('[data-recent="bgColor"]');
-
-    const make = (hex, key) => {
-      const b = document.createElement("button");
-      b.type = "button"; b.title = hex;
-      b.className = "size-6 rounded-full border";
-      b.style.background = hex;
-      b.dataset.colorPreset = key;
-      b.dataset.value = hex;
-      b.addEventListener("click", () => {
-        const text = key === "textColor" ? textInp : bgInp;
-        const pick = key === "textColor" ? textPick : bgPick;
-        if (text) text.value = hex;
-        if (pick) pick.value = hex;
-        applyStyleBoth(); saveRecent(text, hex);
-      });
-      return b;
+    const anyCard = cardD || cardM;
+    const FALLBACK = {
+      font: (anyCard && anyCard.style.fontFamily) || "var(--font-serif)",
+      text: (anyCard && anyCard.style.color)      || "#111827",
+      bg:   (anyCard && anyCard.style.background) || "#F9FAFB"
     };
 
-    if (wrapText) {
-      wrapText.innerHTML = "";
-      (JSON.parse(localStorage.getItem("recent_text") || "[]"))
-        .forEach(hex => wrapText.appendChild(make(hex, "textColor")));
+    function setCardStyle(el){
+      if (!el) return;
+      el.style.fontFamily = (fontSel && fontSel.value.trim()) || FALLBACK.font;
+      el.style.color      = (textInp && textInp.value.trim()) || FALLBACK.text;
+      el.style.background = (bgInp   && bgInp.value.trim())   || FALLBACK.bg;
     }
-    if (wrapBg) {
-      wrapBg.innerHTML = "";
-      (JSON.parse(localStorage.getItem("recent_bg") || "[]"))
-        .forEach(hex => wrapBg.appendChild(make(hex, "bgColor")));
+    function updateMeta(){
+      const a = (author?.value || "").trim();
+      const t = (title?.value  || "").trim();
+      const meta = [a, t ? `『${t}』` : null].filter(Boolean).join(" ");
+      if (metaD) metaD.textContent = meta;
+      if (metaM) metaM.textContent = meta;
+    }
+    function updateBody(){
+      const v = (body?.value || "");
+      if (contD) contD.textContent = v;
+      if (contM) contM.textContent = v;
+    }
+    function applyStyleBoth(){ setCardStyle(cardD); setCardStyle(cardM); }
+
+    function bindPair(textInput, colorInput){
+      if (!textInput || !colorInput) return;
+      colorInput.addEventListener("input", e => {
+        textInput.value = e.target.value;
+        applyStyleBoth();
+      });
+      textInput.addEventListener("input", e => {
+        if (/^#/.test(e.target.value)) colorInput.value = e.target.value;
+        applyStyleBoth();
+      });
+    }
+
+    // クイックフォント
+    form.querySelectorAll('[data-quick-font]').forEach(btn => {
+      btn.addEventListener("click", () => {
+        if (!fontSel) return;
+        fontSel.value = btn.dataset.quickFont;
+        fontSel.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+    });
+
+    function rgbToHex(rgb) {
+      const m = rgb.match(/\d+/g);
+      if (!m) return "";
+      return "#" + m.slice(0, 3).map(n => ("0" + parseInt(n, 10).toString(16)).slice(-2)).join("");
+    }
+    function saveRecent(inputEl, hex) {
+      if (!hex || !hex.startsWith("#")) return;
+      const key = inputEl === textInp ? "recent_text" : "recent_bg";
+      const arr = JSON.parse(localStorage.getItem(key) || "[]").filter(v => v !== hex);
+      arr.unshift(hex);
+      localStorage.setItem(key, JSON.stringify(arr.slice(0, 8)));
+      renderRecent();
+    }
+    function renderRecent() {
+      const wrapText = form.querySelector('[data-recent="textColor"]');
+      const wrapBg   = form.querySelector('[data-recent="bgColor"]');
+      const make = (hex, key) => {
+        const b = document.createElement("button");
+        b.type = "button"; b.title = hex;
+        b.className = "size-6 rounded-full border";
+        b.style.background = hex;
+        b.dataset.colorPreset = key;
+        b.dataset.value = hex;
+        b.addEventListener("click", () => {
+          const text = key === "textColor" ? textInp : bgInp;
+          const pick = key === "textColor" ? textPick : bgPick;
+          if (text) text.value = hex;
+          if (pick) pick.value = hex;
+          applyStyleBoth(); saveRecent(text, hex);
+        });
+        return b;
+      };
+      if (wrapText) {
+        wrapText.innerHTML = "";
+        (JSON.parse(localStorage.getItem("recent_text") || "[]"))
+          .forEach(hex => wrapText.appendChild(make(hex, "textColor")));
+      }
+      if (wrapBg) {
+        wrapBg.innerHTML = "";
+        (JSON.parse(localStorage.getItem("recent_bg") || "[]"))
+          .forEach(hex => wrapBg.appendChild(make(hex, "bgColor")));
+      }
+    }
+
+    form.querySelectorAll('[data-color-preset]').forEach(btn => {
+      btn.addEventListener("click", (e) => {
+        const key = e.currentTarget.dataset.colorPreset;
+        const val = e.currentTarget.dataset.value;
+        const text = key === "textColor" ? textInp : bgInp;
+        const pick = key === "textColor" ? textPick : bgPick;
+        if (text) text.value = val;
+        if (pick) pick.value = val;
+        applyStyleBoth(); saveRecent(text, val);
+      });
+    });
+    form.querySelectorAll('[data-clear-color]').forEach(btn => {
+      btn.addEventListener("click", (e) => {
+        const key = e.currentTarget.dataset.clearColor;
+        const text = key === "textColor" ? textInp : bgInp;
+        if (text) text.value = "";
+        applyStyleBoth();
+      });
+    });
+    form.querySelectorAll('[data-pick-current]').forEach(btn => {
+      btn.addEventListener("click", (e) => {
+        const key = e.currentTarget.dataset.pickCurrent;
+        const text = key === "textColor" ? textInp : bgInp;
+        const prop = key === "textColor" ? "color" : "backgroundColor";
+        const source = cardD || cardM;
+        const val = source ? rgbToHex(getComputedStyle(source)[prop]) : "";
+        if (text && val) text.value = val;
+        const pick = key === "textColor" ? textPick : bgPick;
+        if (pick) pick.value = val;
+        applyStyleBoth(); saveRecent(text, val);
+      });
+    });
+
+    [title, author].forEach(el => el && el.addEventListener("input", updateMeta));
+    body && body.addEventListener("input", updateBody);
+    fontSel && fontSel.addEventListener("change", applyStyleBoth);
+    bindPair(textInp, textPick);
+    bindPair(bgInp, bgPick);
+
+    // 初期表示
+    updateMeta(); updateBody(); applyStyleBoth(); renderRecent();
+
+    // モバイル：展開/収納
+    const toggleBtn = document.getElementById('toggle-mobile-preview');
+    if (toggleBtn && cardM){
+      let expanded = true;
+      toggleBtn.addEventListener('click', () => {
+        expanded = !expanded;
+        cardM.style.maxHeight = expanded ? '28vh' : '10vh';
+        cardM.style.overflow  = 'auto';
+      });
     }
   }
 
-  // プリセット/未指定/現在色
-  form.querySelectorAll('[data-color-preset]').forEach(btn => {
-    btn.addEventListener("click", (e) => {
-      const key = e.currentTarget.dataset.colorPreset;
-      const val = e.currentTarget.dataset.value;
-      const text = key === "textColor" ? textInp : bgInp;
-      const pick = key === "textColor" ? textPick : bgPick;
-      if (text) text.value = val;
-      if (pick) pick.value = val;
-      applyStyleBoth(); saveRecent(text, val);
-    });
-  });
-  form.querySelectorAll('[data-clear-color]').forEach(btn => {
-    btn.addEventListener("click", (e) => {
-      const key = e.currentTarget.dataset.clearColor;
-      const text = key === "textColor" ? textInp : bgInp;
-      if (text) text.value = "";
-      applyStyleBoth();
-    });
-  });
-  form.querySelectorAll('[data-pick-current]').forEach(btn => {
-    btn.addEventListener("click", (e) => {
-      const key = e.currentTarget.dataset.pickCurrent;
-      const text = key === "textColor" ? textInp : bgInp;
-      const prop = key === "textColor" ? "color" : "backgroundColor";
-      const source = cardD || cardM;
-      const val = source ? rgbToHex(getComputedStyle(source)[prop]) : "";
-      if (text && val) text.value = val;
-      const pick = key === "textColor" ? textPick : bgPick;
-      if (pick) pick.value = val;
-      applyStyleBoth(); saveRecent(text, val);
-    });
-  });
-
-  // イベント
-  [title, author].forEach(el => el && el.addEventListener("input", updateMeta));
-  body && body.addEventListener("input", updateBody);
-  fontSel && fontSel.addEventListener("change", applyStyleBoth);
-  bindPair(textInp, textPick);
-  bindPair(bgInp, bgPick);
-
-  // 初期反映
-  updateMeta(); updateBody(); applyStyleBoth(); renderRecent();
-
-  // モバイル：展開/収納
-  const toggleBtn = document.getElementById('toggle-mobile-preview');
-  if (toggleBtn && cardM){
-    let expanded = true;
-    toggleBtn.addEventListener('click', () => {
-      expanded = !expanded;
-      cardM.style.maxHeight = expanded ? '28vh' : '10vh';
-      cardM.style.overflow  = 'auto';
-    });
-  }
+  // Turbo でも通常遷移でも確実に初期化
+  document.addEventListener("turbo:load",   setupPreview);
+  document.addEventListener("turbo:render", setupPreview);
+  if (document.readyState !== "loading") setupPreview();
+  else document.addEventListener("DOMContentLoaded", setupPreview);
 })();
 </script>

--- a/app/views/shared/_color_picker.html.erb
+++ b/app/views/shared/_color_picker.html.erb
@@ -1,11 +1,10 @@
-<%# 引数: f:, field:, label:, key:, default_color: %>
 <div
   data-controller="color-picker"
-  data-color-picker-key-value="<%= key %>"
->
+  data-color-picker-key-value="<%= picker_key %>"><!-- 例: "text" / "bg" -->
+
   <%= f.label field, label, class: "block font-semibold mb-1" %>
 
-  <!-- プリセット（必要に応じて増減OK） -->
+  <!-- プリセット -->
   <div class="flex flex-wrap gap-2 mb-2">
     <% [
       "#111827", "#374151", "#6B7280", "#9CA3AF", "#F9FAFB",
@@ -25,21 +24,21 @@
     <%= f.text_field field,
           class: "input input-bordered w-full",
           placeholder: default_color,
-          value: default_color,
-          data: {
-            "color-picker-target": "field",
-            "preview-target": key
-          } %>
+          value: (f.object.public_send(field) || default_color),
+          data: { action: "input->color-picker#manual change->color-picker#manual",
+                  color_picker_target: "field" } %>
 
     <input type="color"
            class="input w-12 p-0"
-           value="<%= default_color %>"
-           data-color-picker-target="native"
-           data-action="input->color-picker#choose" />
+           value="<%= (f.object.public_send(field) || default_color) %>"
+           data-action="input->color-picker#choose change->color-picker#choose"
+           data-color-picker-target="native" />
 
-    <span class="badge" data-color-picker-target="badge"><%= default_color.upcase %></span>
+    <span class="badge" data-color-picker-target="badge">
+      <%= (f.object.public_send(field) || default_color).upcase %>
+    </span>
   </div>
 
-  <!-- 最近使った色（JSで自動描画） -->
+  <!-- 最近使った色（JSで差し込む） -->
   <div class="mt-2 flex flex-wrap gap-2" data-color-picker-target="recent"></div>
 </div>


### PR DESCRIPTION
## 概要
- カラーのプリセット丸（パレット）をクリックで反映できるように実装
- 文字色／背景色の入力・カラーピッカー・プリセット丸の双方向同期を実現
- 右側プレビューが即時に反映されるよう安定化（イベント駆動）
- 最近使った色をローカル保存し、ワンクリックで再適用できるUIを追加

## 変更点
- app/views/passage_customizations/_color_field_with_palette.html.erb
  - data-controller="color-picker" を導入
  - Targets: field, native, badge, recent を定義
  - data-preview-target="textColor" | "bgColor" をテキスト入力へ付与し、プレビュー連動
  - プリセット丸で data-action="click->color-picker#pick" を使用
- app/views/passage_customizations/_form.html.erb
  - フォーム内部JSを整理し、input/change イベントでプレビュー更新（フォント／文字色／背景色）
  - クイックフォントボタンは change を発火してプレビューへ反映
  - フォールバック値（未設定時の見た目）を data-fallback-* で明示
  - SP時のプレビューへジャンプFAB（IntersectionObserver）を維持
- （前提）Stimulus 登録
  - color-picker コントローラを1回だけ application.register("color-picker", ColorPickerController) で登録