### PR TITLE
自動クローズ & ボタン撤去／アクセシビリティ改善

### DIFF
--- a/app/controllers/thought_logs_controller.rb
+++ b/app/controllers/thought_logs_controller.rb
@@ -1,6 +1,8 @@
+# app/controllers/thought_logs_controller.rb
 class ThoughtLogsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_passage
+  before_action :set_thought_log, only: :destroy
 
   def new
     @thought_log = @passage.thought_logs.new
@@ -16,12 +18,24 @@ class ThoughtLogsController < ApplicationController
     end
   end
 
+  def destroy
+    @thought_log.destroy!
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.remove(@thought_log) }
+      format.html { redirect_to passage_path(@passage), notice: "思考ログを削除しました。" }
+    end
+  end
+
   private
 
   def set_passage
     @passage = current_user.passages.find(params[:passage_id])
   rescue ActiveRecord::RecordNotFound
     redirect_to dashboard_path, alert: "このカードは見つからないか、あなたのものではありません。"
+  end
+
+  def set_thought_log
+    @thought_log = @passage.thought_logs.find(params[:id])
   end
 
   def thought_log_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,11 @@ class UsersController < ApplicationController
   def show
     @user = current_user
     @passages_count = @user.passages.count
-    @recent_passages = @user.passages.order(created_at: :desc).limit(12)
+    @recent_passages =
+      @user.passages
+           .includes(:customization, :book_info) # ★ 追加
+           .order(created_at: :desc)
+           .limit(12)
   end
 
   def hide_guide

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,20 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { timeout: { type: Number, default: 0 } }
+
+  connect() {
+    if (this.timeoutValue > 0) {
+      this.timer = setTimeout(() => this.dismiss(), this.timeoutValue)
+    }
+  }
+
+  disconnect() {
+    if (this.timer) clearTimeout(this.timer)
+  }
+
+  dismiss() {
+    this.element.classList.add("transition-opacity", "duration-200", "opacity-0")
+    setTimeout(() => this.element.remove(), 200)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,6 +6,8 @@ import ColorPickerController from "./color_picker_controller";
 import HelloController       from "./hello_controller";
 import LashController        from "./lash_controller";
 import WelcomeController     from "./welcome_controller";
+import LogFormController from "./log_form_controller";
+import FlashController from "./flash_controller"
 
 application.register("book-search",  BookSearchController);
 application.register("onboarding",   OnboardingController);
@@ -13,6 +15,8 @@ application.register("color-picker",  ColorPickerController);
 application.register("hello",        HelloController);
 application.register("lash",         LashController);
 application.register("welcome",      WelcomeController);
+application.register("log-form", LogFormController);
+application.register("flash", FlashController)
 
 // 余計な Application.start() や window.Stimulus の代入は不要
 export {};

--- a/app/javascript/controllers/log_form_controller.js
+++ b/app/javascript/controllers/log_form_controller.js
@@ -1,0 +1,110 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static values = { passageId: Number };
+  static targets = ["form", "textarea", "preview", "counter"];
+
+  connect() {
+    this.key = `qc:logdraft:${this.passageIdValue || "unknown"}`;
+    this._dirty = false;
+
+    // load draft
+    const draft = localStorage.getItem(this.key);
+    if (draft && !this.textareaTarget.value) {
+      this.textareaTarget.value = draft;
+    }
+
+    // bind
+    this.updateUI();
+
+    this._onBeforeUnload = (e) => {
+      if (this._dirty && this.textareaTarget.value.trim().length > 0) {
+        e.preventDefault();
+        e.returnValue = "";
+      }
+    };
+    window.addEventListener("beforeunload", this._onBeforeUnload);
+
+    this._onKeyDown = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        this.formTarget.requestSubmit();
+      }
+    };
+    this.textareaTarget.addEventListener("keydown", this._onKeyDown);
+  }
+
+  disconnect() {
+    window.removeEventListener("beforeunload", this._onBeforeUnload);
+    this.textareaTarget?.removeEventListener("keydown", this._onKeyDown);
+  }
+
+  // 入力ハンドラ
+  input() {
+    this._dirty = true;
+    this.saveDraft();
+    this.updateUI();
+  }
+
+  // 送信時
+  submitted() {
+    localStorage.removeItem(this.key);
+    this._dirty = false;
+  }
+
+  // 雛形やチップの挿入
+  insertAtCursor({ params }) {
+    const text = params.text || "";
+    const el = this.textareaTarget;
+    const start = el.selectionStart ?? el.value.length;
+    const end   = el.selectionEnd   ?? el.value.length;
+    const before = el.value.slice(0, start);
+    const after  = el.value.slice(end);
+    const needsNL = before && !before.endsWith("\n") ? "\n" : "";
+    el.value = `${before}${needsNL}${text}\n${after}`;
+    el.focus();
+    el.selectionStart = el.selectionEnd = (before + needsNL + text + "\n").length;
+    this._dirty = true;
+    this.saveDraft();
+    this.updateUI();
+  }
+
+  // 簡易ツールバー（太字・箇条書きなどの雛形）
+  toolbar({ params }) {
+    const type = params.type;
+    const sel = this.textareaTarget;
+    const hasSelection = sel.selectionStart !== sel.selectionEnd;
+    const selected = sel.value.substring(sel.selectionStart, sel.selectionEnd);
+    let snippet = "";
+
+    switch (type) {
+      case "bold":       snippet = hasSelection ? `**${selected}**` : `**強調**`; break;
+      case "italic":     snippet = hasSelection ? `*${selected}*`  : `*斜体*`;   break;
+      case "list":       snippet = "- ポイント1\n- ポイント2\n- ポイント3";     break;
+      case "todo":       snippet = "- [ ] やること1\n- [ ] やること2";          break;
+      case "quote":      snippet = `> 引用や要点を一行で`;                     break;
+      default:           snippet = "";
+    }
+    this.insertAtCursor({ params: { text: snippet } });
+  }
+
+  // ===== helpers =====
+  saveDraft() {
+    // デバウンスなし（シンプル＆軽い）にしています
+    try { localStorage.setItem(this.key, this.textareaTarget.value); } catch {}
+  }
+
+  updateUI() {
+    const v = this.textareaTarget.value || "";
+    if (this.hasPreviewTarget) {
+      // シンプルプレビュー（改行のみ反映）
+      this.previewTarget.innerHTML = v
+        .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;").replace(/\n/g, "<br>");
+    }
+    if (this.hasCounterTarget) {
+      const len = v.length;
+      const lines = (v.match(/\n/g) || []).length + 1;
+      this.counterTarget.textContent = `${len} 文字 / ${lines} 行`;
+    }
+  }
+}

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -24,12 +24,16 @@
           <%= link_to (defined?(new_passage_path) ? new_passage_path : "#"), class: "btn btn-primary breeze" do %>
             ＋ 一節を記録
           <% end %>
+
           <%= link_to (defined?(passages_path) ? passages_path : "#"), class: "btn btn-outline hover-float" do %>
             一覧を見る
           <% end %>
-          <%= link_to edit_user_registration_path, class: "btn btn-ghost hover-float" do %>
-            プロフィール
-          <% end %>
+
+          <!-- プロフィールは閲覧ページへ -->
+          <%= link_to "プロフィール", user_path(current_user), class: "btn btn-ghost hover-float" %>
+
+          <!-- 設定は別ボタンで -->
+          <%= link_to "アカウント設定", edit_user_registration_path, class: "btn btn-outline hover-float" %>
         </div>
       </div>
     </div>
@@ -83,7 +87,6 @@
 <% end %>
   </section>
 
-  <!-- ショートガイド：森の黒板っぽく -->
   <section class="mt-10 grid gap-4 md:grid-cols-3">
     <div class="rounded-2xl gh-glass p-6 hover-float">
       <div class="text-2xl">✍️</div>

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -34,7 +34,7 @@
         <% end %>
 
         <div class="text-lg md:text-2xl font-semibold leading-relaxed">
-          <%= simple_format(h(@passage.content)) %>
+          <%= simple_format(h(@passage.content), { class: "m-0" }, wrapper_tag: "div") %>
         </div>
       </div>
 
@@ -228,19 +228,25 @@
           </div>
 
           <% if @thought_logs.present? %>
-            <div class="mt-4 space-y-3">
-              <% @thought_logs.each do |log| %>
-                <article class="rounded-2xl gh-glass p-4 hover-float">
-                  <div class="flex items-center justify-between text-xs opacity-70 mb-2">
-                    <span>記録日時</span>
-                    <time datetime="<%= log.created_at.iso8601 %>"><%= l log.created_at, format: :long %></time>
-                  </div>
-                  <div class="leading-relaxed text-sm whitespace-pre-wrap">
-                    <%= h(log.content) %>
-                  </div>
-                </article>
-              <% end %>
-            </div>
+  <div class="mt-4 space-y-3">
+    <% @thought_logs.each do |log| %>
+      <article id="<%= dom_id(log) %>" class="rounded-2xl gh-glass p-4 hover-float">
+        <div class="flex items-center justify-between text-xs opacity-70 mb-2">
+          <span>記録日時</span>
+          <div class="flex items-center gap-2">
+            <time datetime="<%= log.created_at.iso8601 %>"><%= l log.created_at, format: :long %></time>
+            <% if user_signed_in? && @passage.user_id == current_user.id %>
+              <%= link_to "削除",
+                    passage_thought_log_path(@passage, log),
+                    data: { turbo_method: :delete, turbo_confirm: "このログを削除します。よろしいですか？" },
+                    class: "link link-error text-[11px]" %>
+            <% end %>
+          </div>
+        </div>
+        <div class="leading-relaxed text-sm whitespace-pre-wrap"><%= h(log.content) %></div>
+      </article>
+    <% end %>
+  </div>
           <% else %>
             <div class="mt-4 rounded-2xl gh-glass p-6 text-center hover-float">
               <p class="font-semibold">まだ思考ログはありません</p>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,19 +1,23 @@
 <% if notice.present? || alert.present? %>
-  <div data-controller="flash" class="space-y-2 mb-4">
+  <div class="space-y-2 mb-4">
     <% if notice.present? %>
-      <div class="alert alert-info shadow-sm animate-fade-in" data-flash-target="item" role="status">
+      <div class="alert alert-info shadow-sm animate-fade-in"
+           data-controller="flash"
+           data-flash-timeout-value="4000"
+           role="status" aria-live="polite">
         <div class="flex-1"><%= notice %></div>
-        <button type="button" class="btn btn-sm" data-action="click->flash#dismiss">OK</button>
       </div>
     <% end %>
+
     <% if alert.present? %>
-      <div class="alert alert-error shadow-sm animate-fade-in" data-flash-target="item" role="alert">
+      <div class="alert alert-error shadow-sm animate-fade-in"
+           data-controller="flash"
+           data-flash-timeout-value="5000"
+           role="alert" aria-live="assertive">
         <div class="flex-1"><%= alert %></div>
-        <button type="button" class="btn btn-sm" data-action="click->flash#dismiss">閉じる</button>
       </div>
     <% end %>
   </div>
 <% else %>
-  <!-- 高さ確保でガタつき防止 -->
   <div class="min-h-6"></div>
 <% end %>

--- a/app/views/thought_logs/new.html.erb
+++ b/app/views/thought_logs/new.html.erb
@@ -8,13 +8,27 @@
     <%= link_to "← 戻る", passage_path(@passage), class: "link link-primary" %>
   </div>
 
-  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-visible md:overflow-visible">
+  <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-visible"
+       data-controller="log-form"
+       data-log-form-passage-id-value="<%= @passage.id %>">
     <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full
                 bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
 
-    <h1 class="text-2xl md:text-3xl font-extrabold gh-underline mb-6">思考ログを追加</h1>
+    <h1 class="text-2xl md:text-3xl font-extrabold gh-underline mb-4">思考ログを追加</h1>
 
-    <%= form_with model: [@passage, @thought_log], local: true, class: "space-y-5" do |f| %>
+    <!-- passage メタ（文脈の想起） -->
+    <% if @passage.title.present? || @passage.author.present? %>
+      <div class="text-xs opacity-70 mb-4">
+        対象: <%= [@passage.author, @passage.title.presence&.then { "『#{_1}』" }].compact.join(" ") %>
+      </div>
+    <% end %>
+
+    <%= form_with model: [@passage, @thought_log],
+                  local: true,
+                  data: { action: "turbo:submit-end->log-form#submitted" },
+                  class: "space-y-4",
+                  html: { data: { "log-form-target": "form" } } do |f| %>
+
       <% if @thought_log.errors.any? %>
         <div class="alert alert-error">
           <span>入力にエラーがあるよ（<%= @thought_log.errors.count %>件）</span>
@@ -26,10 +40,63 @@
         </div>
       <% end %>
 
-      <!-- 思考ログ本文 -->
-      <div>
-        <%= f.label :content, "思考ログ", class: "block font-semibold mb-1" %>
-        <%= f.text_area :content, rows: 5, class: "textarea textarea-bordered w-full" %>
+      <!-- ツールバー -->
+      <div class="flex flex-wrap gap-2">
+        <button type="button" class="btn btn-xs" data-action="log-form#toolbar"
+                data-log-form-type-param="bold">太字</button>
+        <button type="button" class="btn btn-xs" data-action="log-form#toolbar"
+                data-log-form-type-param="italic">斜体</button>
+        <button type="button" class="btn btn-xs" data-action="log-form#toolbar"
+                data-log-form-type-param="list">箇条書き</button>
+        <button type="button" class="btn btn-xs" data-action="log-form#toolbar"
+                data-log-form-type-param="todo">TODO</button>
+        <button type="button" class="btn btn-xs" data-action="log-form#toolbar"
+                data-log-form-type-param="quote">引用</button>
+
+        <span class="opacity-50">|</span>
+
+        <!-- 書き出しチップ -->
+        <% chips = [
+          "なぜ心に残った？",
+          "どんな状況・気分で読んだ？",
+          "一言で要約すると？",
+          "今後の自分にどう効きそう？",
+          "これから試す小さな一歩は？"
+        ] %>
+        <% chips.each do |t| %>
+          <button type="button" class="btn btn-ghost btn-xs"
+                  title="本文に挿入"
+                  data-action="log-form#insertAtCursor"
+                  data-log-form-text-param="■ <%= t %>"><%= t %></button>
+        <% end %>
+
+        <span class="opacity-50">|</span>
+
+        <!-- 気分チップ -->
+        <% %w(🙂 😌 🤔 😮 😢 🔥).each do |emo| %>
+          <button type="button" class="btn btn-ghost btn-xs"
+                  data-action="log-form#insertAtCursor"
+                  data-log-form-text-param="<%= emo %> "><%= emo %></button>
+        <% end %>
+      </div>
+
+      <!-- 本文＋プレビュー -->
+      <div class="grid gap-4 md:grid-cols-2">
+        <div>
+          <%= f.label :content, "思考ログ", class: "block font-semibold mb-1" %>
+          <%= f.text_area :content,
+                rows: 10,
+                class: "textarea textarea-bordered w-full",
+                data: { "log-form-target": "textarea", action: "input->log-form#input" } %>
+          <div class="mt-1 text-xs opacity-70" data-log-form-target="counter"></div>
+          <p class="text-[11px] opacity-60 mt-1">⌘(Ctrl)+Enter で保存</p>
+        </div>
+
+        <div class="rounded-xl gh-glass p-3">
+          <div class="text-xs opacity-70 mb-1">プレビュー（保存前）</div>
+          <div class="text-sm leading-relaxed whitespace-normal"
+               data-log-form-target="preview"></div>
+        </div>
       </div>
 
       <div class="flex gap-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   get "/guide", to: "static#guide", as: :guide
   patch "users/hide_guide", to: "users#hide_guide"
 
+  resources :users, only: [ :show ]
+
   # 書籍検索フォーム画面
   resources :book_infos, only: [] do
     collection do
@@ -30,7 +32,7 @@ Rails.application.routes.draw do
 
   # passages
   resources :passages, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
-    resources :thought_logs, only: [ :new, :create ]
+    resources :thought_logs, only: [ :new, :create, :destroy ]
     resource  :customization, only: [ :new, :create, :edit, :update ],
               controller: "passage_customizations"
   end


### PR DESCRIPTION
## 概要
- 「OK/閉じる」ボタンが実質ノーオペだったため変更
- メッセージは読み終わる頃に自動的に消えるようにしました。
- アクセシビリティ（role/aria-live）を整備しました。

## 変更点
- shared/_flash.html.erb を更新
  - ボタンを削除し、自動でフェードアウト（info: 4s / error: 5s）に変更
  - role="status" / role="alert" と aria-live を付与
- app/javascript/controllers/flash_controller.js を追加
  - data-flash-timeout-value 秒後に opacity-0 を付けてDOMから削除
  - タイマーのクリーンアップを disconnect で実施
- Stimulus 登録（既存の controllers/index.js に flash を登録）