### PR TITLE
戻る動作の最適化・思考ログ削除・一行目ズレ解消／LPギャラリー差し替え＆ロードマップ更新

### DIFF
--- a/app/controllers/passage_customizations_controller.rb
+++ b/app/controllers/passage_customizations_controller.rb
@@ -11,7 +11,7 @@ class PassageCustomizationsController < ApplicationController
   def create
     @customization = @passage.build_customization(customization_params.merge(user: current_user))
     if @customization.save
-      redirect_to @passage, notice: "カスタマイズを保存したよ。"
+      redirect_to passage_path(@passage, from: "customize"), notice: "見た目を保存しました。"
     else
       flash.now[:alert] = "保存に失敗しちゃった…入力を見直してね。"
       render :new, status: :unprocessable_entity
@@ -25,7 +25,7 @@ class PassageCustomizationsController < ApplicationController
   def update
     @customization = @passage.customization
     if @customization.update(customization_params)
-      redirect_to @passage, notice: "カスタマイズを更新したよ。"
+      redirect_to passage_path(@passage, from: "customize"), notice: "見た目を更新しました。"
     else
       flash.now[:alert] = "更新に失敗しちゃった…入力を見直してね。"
       render :edit, status: :unprocessable_entity

--- a/app/views/passages/show.html.erb
+++ b/app/views/passages/show.html.erb
@@ -6,7 +6,11 @@
 
 <div class="container mx-auto max-w-7xl px-4 md:px-8 py-8 md:py-12">
   <div class="mb-6">
-    <%= link_to "← 戻る", (request.referer || root_path), class: "link link-primary" %>
+    <%# ========== 戻るリンク：カスタマイズ画面から来た場合は一覧/ダッシュボードへ ========== %>
+    <% default_back = (defined?(passages_path) ? passages_path : root_path) %>
+    <% ref        = request.referer.to_s %>
+    <% back_to    = (ref.present? && !ref.match?(%r{/customization(?:/|\z)})) ? ref : default_back %>
+    <%= link_to "← 戻る", back_to, class: "link link-primary" %>
   </div>
 
   <%# --- 安全なフォールバック（@style が無い場合でも実効値を計算） --- %>
@@ -34,7 +38,8 @@
         <% end %>
 
         <div class="text-lg md:text-2xl font-semibold leading-relaxed">
-          <%= simple_format(h(@passage.content), { class: "m-0" }, wrapper_tag: "div") %>
+          <%# simple_format は内部でエスケープするので h(...) は不要。1行目のズレ防止に wrapper を div + m-0 %>
+          <%= simple_format(@passage.content, { class: "m-0" }, wrapper_tag: "div") %>
         </div>
       </div>
 
@@ -80,125 +85,92 @@
         </div>
 
         <% if @passage.book_info.present? %>
-  <% b = @passage.book_info %>
+          <% b = @passage.book_info %>
+          <section class="mt-6">
+            <h2 class="text-xl md:text-2xl font-bold gh-underline mb-2">書誌情報</h2>
 
-<section class="mt-6">
-  <h2 class="text-xl md:text-2xl font-bold gh-underline mb-2">書誌情報</h2>
+            <div class="rounded-2xl gh-glass p-5">
+              <div class="flex gap-4 items-start">
+                <%# カバー画像 or プレースホルダ %>
+                <% if b&.cover_url.present? %>
+                  <%= image_tag b.cover_url, alt: (b.title.presence || "Book cover"),
+                        class: "w-16 h-24 object-cover rounded", loading: "lazy", decoding: "async" %>
+                <% else %>
+                  <div class="w-16 h-24 rounded bg-base-200 grid place-items-center text-[10px] opacity-60">
+                    No Cover
+                  </div>
+                <% end %>
 
-  <div class="rounded-2xl gh-glass p-5">
-    <div class="flex gap-4 items-start">
-      <%# カバー画像 or プレースホルダ %>
-      <% if b&.cover_url.present? %>
-        <%= image_tag b.cover_url, alt: (b.title.presence || "Book cover"),
-              class: "w-16 h-24 object-cover rounded", loading: "lazy", decoding: "async" %>
-      <% else %>
-        <div class="w-16 h-24 rounded bg-base-200 grid place-items-center text-[10px] opacity-60">
-          No Cover
-        </div>
-      <% end %>
+                <div class="flex-1 min-w-0">
+                  <div class="font-semibold truncate"><%= b&.title.presence || "(書名未設定)" %></div>
+                  <div class="opacity-70 text-sm truncate"><%= b&.author.presence || "-" %></div>
 
-      <div class="flex-1 min-w-0">
-        <div class="font-semibold truncate"><%= b&.title.presence || "(書名未設定)" %></div>
-        <div class="opacity-70 text-sm truncate"><%= b&.author.presence || "-" %></div>
+                  <dl class="grid grid-cols-3 gap-y-1 gap-x-3 text-[13px] mt-2">
+                    <dt class="opacity-70">出版社</dt>
+                    <dd class="col-span-2 break-words"><%= b&.publisher.presence || "-" %></dd>
 
-        <dl class="grid grid-cols-3 gap-y-1 gap-x-3 text-[13px] mt-2">
-          <dt class="opacity-70">出版社</dt>
-          <dd class="col-span-2 break-words"><%= b&.publisher.presence || "-" %></dd>
+                    <dt class="opacity-70">出版日</dt>
+                    <dd class="col-span-2">
+                      <%= b&.published_date ? time_tag(b.published_date, b.published_date.to_s, datetime: b.published_date.iso8601) : "-" %>
+                    </dd>
 
-          <dt class="opacity-70">出版日</dt>
-          <dd class="col-span-2">
-            <%= b&.published_date ? time_tag(b.published_date, b.published_date.to_s, datetime: b.published_date.iso8601) : "-" %>
-          </dd>
+                    <dt class="opacity-70">ISBN</dt>
+                    <dd class="col-span-2">
+                      <% isbn = b&.isbn.to_s.strip.presence %>
+                      <% if isbn %>
+                        <code><%= isbn %></code>
+                        <button type="button" class="btn btn-ghost btn-xs ml-2" data-copy-isbn="<%= isbn %>">コピー</button>
+                      <% else %>
+                        -
+                      <% end %>
+                    </dd>
 
-          <dt class="opacity-70">ISBN</dt>
-          <dd class="col-span-2">
-            <% isbn = b&.isbn.to_s.strip.presence %>
-            <% if isbn %>
-              <code><%= isbn %></code>
-              <button type="button" class="btn btn-ghost btn-xs ml-2" data-copy-isbn="<%= isbn %>">コピー</button>
-            <% else %>
-              -
-            <% end %>
-          </dd>
+                    <dt class="opacity-70">ページ数</dt>
+                    <dd class="col-span-2"><%= (b&.page_count.present? && b.page_count > 0) ? b.page_count : "-" %></dd>
 
-          <dt class="opacity-70">ページ数</dt>
-          <dd class="col-span-2"><%= (b&.page_count.present? && b.page_count > 0) ? b.page_count : "-" %></dd>
+                    <dt class="opacity-70">提供元</dt>
+                    <dd class="col-span-2 flex items-center gap-2">
+                      <span class="badge badge-ghost"><%= b&.source.presence || "未設定" %></span>
+                      <% ext_url =
+                           if b&.source == "google_books" && b&.source_id.present?
+                             "https://books.google.com/books?id=#{ERB::Util.url_encode(b.source_id)}"
+                           elsif b&.source == "open_library" && b&.source_id.present?
+                             "https://openlibrary.org#{b.source_id}"
+                           end %>
+                      <% if ext_url.present? %>
+                        <%= link_to "外部ページを開く", ext_url, class: "link link-primary text-xs",
+                              target: "_blank", rel: "noopener noreferrer" %>
+                      <% end %>
+                    </dd>
+                  </dl>
+                </div>
+              </div>
+            </div>
+          </section>
 
-          <dt class="opacity-70">提供元</dt>
-          <dd class="col-span-2 flex items-center gap-2">
-            <span class="badge badge-ghost"><%= b&.source.presence || "未設定" %></span>
-            <% ext_url =
-                 if b&.source == "google_books" && b&.source_id.present?
-                   "https://books.google.com/books?id=#{ERB::Util.url_encode(b.source_id)}"
-                 elsif b&.source == "open_library" && b&.source_id.present?
-                   "https://openlibrary.org#{b.source_id}"
-                 end %>
-            <% if ext_url.present? %>
-              <%= link_to "外部ページを開く", ext_url, class: "link link-primary text-xs",
-                    target: "_blank", rel: "noopener noreferrer" %>
-            <% end %>
-          </dd>
-        </dl>
-
-        <%# 追加入力導線（未設定時のガイド） %>
-        <% unless b %>
-          <div class="mt-3">
-            <%= link_to "書誌情報を追加する", edit_passage_path(@passage, open: "book_search"),
-                  class: "btn btn-outline btn-sm" %>
-            <p class="text-xs opacity-70 mt-1">編集画面で「🔎 書籍を検索してセット」を押してね</p>
-          </div>
+          <%# --- ISBN コピー（重複なし・一度だけバインド） --- %>
+          <script>
+          (function attachCopyOnce(){
+            if (window.__isbnCopyBound) return;
+            window.__isbnCopyBound = true;
+            document.addEventListener("click", (e) => {
+              const btn = e.target.closest("[data-copy-isbn]");
+              if (!btn) return;
+              const v = btn.getAttribute("data-copy-isbn") || "";
+              if (!v) return;
+              if (navigator.clipboard?.writeText) {
+                navigator.clipboard.writeText(v);
+              } else {
+                const ta = document.createElement("textarea");
+                ta.value = v; document.body.appendChild(ta);
+                ta.select(); document.execCommand("copy"); ta.remove();
+              }
+              btn.classList.add("btn-success"); btn.textContent = "コピーしたよ";
+              setTimeout(() => { btn.classList.remove("btn-success"); btn.textContent = "コピー"; }, 1200);
+            });
+          })();
+          </script>
         <% end %>
-      </div>
-    </div>
-  </div>
-</section>
-
-<script>
-(function attachCopyOnce(){
-  if (window.__isbnCopyBound) return;
-  window.__isbnCopyBound = true;
-  document.addEventListener("click", (e) => {
-    const btn = e.target.closest("[data-copy-isbn]");
-    if (!btn) return;
-    const v = btn.getAttribute("data-copy-isbn") || "";
-    if (!v) return;
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(v);
-    } else {
-      const ta = document.createElement("textarea");
-      ta.value = v; document.body.appendChild(ta);
-      ta.select(); document.execCommand("copy"); ta.remove();
-    }
-    btn.classList.add("btn-success"); btn.textContent = "コピーしたよ";
-    setTimeout(() => { btn.classList.remove("btn-success"); btn.textContent = "コピー"; }, 1200);
-  });
-})();
-</script>
-
-  <script>
-    // ISBN コピー（必要なときだけ実行）
-    document.addEventListener("click", (e) => {
-      const btn = e.target.closest("[data-copy-isbn]");
-      if (!btn) return;
-      const v = btn.getAttribute("data-copy-isbn");
-      if (!navigator.clipboard) {
-        // フォールバック（ごく簡易）
-        const ta = document.createElement("textarea");
-        ta.value = v; document.body.appendChild(ta);
-        ta.select(); document.execCommand("copy"); ta.remove();
-      } else {
-        navigator.clipboard.writeText(v);
-      }
-      btn.classList.add("btn-success");
-      btn.textContent = "コピーしたよ";
-      setTimeout(() => {
-        btn.classList.remove("btn-success");
-        btn.textContent = "コピー";
-      }, 1200);
-    });
-  </script>
-<% end %>
-
 
         <!-- 思考ログ：この一節に紐づく“考えの連鎖” -->
         <section class="mt-6">
@@ -228,25 +200,25 @@
           </div>
 
           <% if @thought_logs.present? %>
-  <div class="mt-4 space-y-3">
-    <% @thought_logs.each do |log| %>
-      <article id="<%= dom_id(log) %>" class="rounded-2xl gh-glass p-4 hover-float">
-        <div class="flex items-center justify-between text-xs opacity-70 mb-2">
-          <span>記録日時</span>
-          <div class="flex items-center gap-2">
-            <time datetime="<%= log.created_at.iso8601 %>"><%= l log.created_at, format: :long %></time>
-            <% if user_signed_in? && @passage.user_id == current_user.id %>
-              <%= link_to "削除",
-                    passage_thought_log_path(@passage, log),
-                    data: { turbo_method: :delete, turbo_confirm: "このログを削除します。よろしいですか？" },
-                    class: "link link-error text-[11px]" %>
-            <% end %>
-          </div>
-        </div>
-        <div class="leading-relaxed text-sm whitespace-pre-wrap"><%= h(log.content) %></div>
-      </article>
-    <% end %>
-  </div>
+            <div class="mt-4 space-y-3">
+              <% @thought_logs.each do |log| %>
+                <article id="<%= dom_id(log) %>" class="rounded-2xl gh-glass p-4 hover-float">
+                  <div class="flex items-center justify-between text-xs opacity-70 mb-2">
+                    <span>記録日時</span>
+                    <div class="flex items-center gap-2">
+                      <time datetime="<%= log.created_at.iso8601 %>"><%= l log.created_at, format: :long %></time>
+                      <% if user_signed_in? && @passage.user_id == current_user.id %>
+                        <%= link_to "削除",
+                              passage_thought_log_path(@passage, log),
+                              data: { turbo_method: :delete, turbo_confirm: "このログを削除します。よろしいですか？" },
+                              class: "link link-error text-[11px]" %>
+                      <% end %>
+                    </div>
+                  </div>
+                  <div class="leading-relaxed text-sm whitespace-pre-wrap"><%= log.content %></div>
+                </article>
+              <% end %>
+            </div>
           <% else %>
             <div class="mt-4 rounded-2xl gh-glass p-6 text-center hover-float">
               <p class="font-semibold">まだ思考ログはありません</p>
@@ -267,7 +239,6 @@
           <% if user_signed_in? && @passage.user_id == current_user.id %>
             <%= link_to "編集", edit_passage_path(@passage), class: "btn btn-outline btn-press" %>
 
-            <%# カスタマイズ導線（下部にも設置） %>
             <% if @passage.customization.present? %>
               <%= link_to "見た目をカスタマイズ",
                           edit_passage_customization_path(@passage),

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -52,10 +52,11 @@
               </div>
 
               <div class="grid grid-cols-2 gap-4">
+                <!-- Unknown を太宰 治に置換（PD） -->
                 <div class="relative rounded-2xl p-4 border" style="background:#111827; color:#F9FAFB; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">
                   <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl opacity-40"></div>
-                  <div class="text-[10px] opacity-70 mb-1">Unknown『Daily Notes』</div>
-                  <div class="text-sm font-semibold">Keep the words that keep you.</div>
+                  <div class="text-[10px] opacity-70 mb-1">太宰 治『走れメロス』</div>
+                  <div class="text-sm font-semibold">メロスは激怒した。</div>
                 </div>
                 <div class="relative rounded-2xl p-4 border gh-paper" style="color:#065F46; font-family: var(--font-sans);">
                   <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
@@ -123,11 +124,11 @@
       <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         <% samples = [
           {bg:"#FDF2F8", fg:"#4A044E", font:"var(--font-serif)",    meta:"与謝野晶子『みだれ髪』", body:"その手をば柔らかにして我に触れよ"},
-          {bg:"#111827", fg:"#F9FAFB", font:"ui-monospace,SFMono-Regular,Menlo,monospace", meta:"Unknown『Daily Notes』", body:"Write what you don't want to forget."},
+          {bg:"#111827", fg:"#F9FAFB", font:"ui-monospace,SFMono-Regular,Menlo,monospace", meta:"太宰 治『走れメロス』", body:"メロスは激怒した。"},
           {bg:"#ECFDF5", fg:"#065F46", font:"var(--font-sans)",      meta:"川端 康成『雪国』", body:"国境の長いトンネルを抜けると雪国であった。"},
           {bg:"#FEF3C7", fg:"#78350F", font:"var(--font-serif)",    meta:"夏目 漱石『草枕』", body:"智に働けば角が立つ。情に棹させば流される。"},
           {bg:"#DBEAFE", fg:"#1E3A8A", font:"var(--font-sans)",      meta:"吉本ばなな『キッチン』", body:"この世で一番好きな場所は台所だ。"},
-          {bg:"#F3F4F6", fg:"#111827", font:"ui-monospace,SFMono-Regular,Menlo,monospace", meta:"Unknown『Work Log』", body:"Small, steady steps compound."}
+          {bg:"#F3F4F6", fg:"#111827", font:"var(--font-serif)",     meta:"宮沢 賢治『雨ニモマケズ』", body:"雨ニモマケズ 風ニモマケズ"}
         ] %>
         <% samples.each do |c| %>
           <div class="relative rounded-2xl p-6 border"
@@ -148,8 +149,8 @@
       <div class="mt-8 grid gap-6 md:grid-cols-3">
         <%[
           {title:"テーマ切替", body:"気分でダーク／ライトや配色テーマを選択。"},
-          {title:"タグと検索", body:"一節をタグで整理、振り返りをもっと気軽に。"},
-          {title:"共有画像生成", body:"作ったカードを画像出力してシェア。"}
+          {title:"タグと検索", body:"タグ付けとキーワードで、欲しい一節を素早く発見。"},
+          {title:"タグ機能の強化", body:"おすすめタグ・一括編集・並び替えで整理しやすく。"}
         ].each do |f| %>
           <div class="rounded-2xl gh-glass p-6 hover-float">
             <h3 class="font-bold text-xl font-sans"><%= f[:title] %></h3>


### PR DESCRIPTION
## 概要
- 詳細ページ：戻るの挙動改善、思考ログの削除対応、本文1行目の余白ズレ解消しました。
- LP：ギャラリーの例文を日本文学へ差し替え、ロードマップをタグ中心の説明へ更新、アクセシビリティ微調整しました。

## 変更点
1) 一節 詳細ページ（passages#show）
- 戻るリンクの挙動を最適化
  - 参照元が /customization 系なら無視し、一覧（passages_path）へ戻すデフォルトにフォールバック。
  - 通常は request.referer を尊重。
- 本文レンダリングのズレ修正
  - simple_format の wrapper を div、class: "m-0" 指定で先頭行の余白を除去。
- 思考ログセクションを更新
  - 各ログに 削除リンク（data-turbo-method: :delete + confirm）を追加。
  - ログ <article> に id="<%= dom_id(log) %>" を付与（Turbo Stream で削除反映）。
2) 思考ログ削除（ThoughtLogsController#destroy）
- ルーティング：resources :passages do resources :thought_logs, only: [:new, :create, :destroy] end
- コントローラ：
  - before_action :set_passage, :set_thought_log
  - 所有者チェックは set_passage の段階で current_user.passages.find(...) により担保
  - destroy! 実行後、
    - Turbo: turbo_stream.remove(@thought_log)
    - HTML: 詳細ページへリダイレクト & フラッシュ
- ビュー：詳細ページ側から削除実行 → Turbo/HTML 両対応
3) トップページ（LP）
- ギャラリー例文を日本のパブリックドメイン作品に差し替え
  - 例）太宰治『走れメロス』「メロスは激怒した。」、宮沢賢治『雨ニモマケズ』ほか
- ロードマップから「共有画像生成」を削除し、タグ・検索周りに統一
- 装飾要素コンテナに aria-hidden="true" を付与（読み上げ抑止）
- 装飾の pointer-events: none 適用で操作感を阻害しないよう微調整