### PR TITLE
本番メール用 URL のホスト設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,102 +1,66 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # Code is not reloaded between requests.
   config.enable_reloading = false
-
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
-
-  # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
+
   config.action_controller.perform_caching = true
 
-  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
-  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
-  # config.require_master_key = true
-
-  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  # config.public_file_server.enabled = false
-
-  # Compress CSS using a preprocessor.
-  # config.assets.css_compressor = :sass
-
-  # Do not fall back to assets pipeline if a precompiled asset is missed.
+  # Sprockets / assets
   config.assets.compile = false
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.asset_host = "http://assets.example.com"
-
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
-  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
-
-  # Store uploaded files on the local file system (see config/storage.yml for options).
+  # Active Storage（Render だとローカルは短命なので将来的にS3等へ）
   config.active_storage.service = :local
 
-  # Mount Action Cable outside main process or domain.
-  # config.action_cable.mount_path = nil
-  # config.action_cable.url = "wss://example.com/cable"
-  # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
-
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # HTTPS を強制
   config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
-
-  # Log to STDOUT by default
-  config.logger = ActiveSupport::Logger.new(STDOUT)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-
-  # Prepend all log lines with the following tags.
+  # Logging
+  config.logger = ActiveSupport::Logger.new(STDOUT).tap { |l| l.formatter = ::Logger::Formatter.new }
   config.log_tags = [ :request_id ]
-
-  # "info" includes generic and useful information about system operation, but avoids logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
-  # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
-
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
-
-  # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter = :resque
-  # config.active_job.queue_name_prefix = "myapp_production"
-
-  # Disable caching for Action Mailer templates even if Action Controller
-  # caching is enabled.
-  config.action_mailer.perform_caching = false
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
-
-  # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Do not dump schema after migrations.
+  # I18n
+  config.i18n.fallbacks = true
+
+  # DB
   config.active_record.dump_schema_after_migration = false
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  # =========================
+  # Mailer / URL まわり（★重要）
+  # =========================
+  host     = ENV.fetch("APP_HOST", "localhost")       # 例: "quotecanvas.onrender.com"
+  protocol = ENV.fetch("APP_PROTOCOL", "https")       # "https" or "http"
+
+  # Devise の *_url で使われる既定値
+  config.action_mailer.default_url_options = { host:, protocol: }
+
+  # ルーティング層の *_url も揃える
+  Rails.application.routes.default_url_options[:host]     = host
+  Rails.application.routes.default_url_options[:protocol] = protocol
+
+  # メール内の画像などを絶対URLにしたい場合
+  config.action_mailer.asset_host = "#{protocol}://#{host}"
+
+  # 本番ではメールを実際に送る想定に
+  config.action_mailer.perform_caching   = false
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_options = { from: ENV.fetch("MAILER_FROM", "no-reply@#{host}") }
+
+  # （任意）SMTP を環境変数で設定している場合だけ適用
+  if ENV["SMTP_ADDRESS"].present?
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      address:              ENV["SMTP_ADDRESS"],
+      port:                 Integer(ENV.fetch("SMTP_PORT", "587")),
+      user_name:            ENV["SMTP_USERNAME"],
+      password:             ENV["SMTP_PASSWORD"],
+      domain:               ENV.fetch("SMTP_DOMAIN", host),
+      authentication:       ENV.fetch("SMTP_AUTH", "plain"),
+      enable_starttls_auto: ActiveModel::Type::Boolean.new.cast(ENV.fetch("SMTP_STARTTLS", "true"))
+    }.compact
+  end
 end


### PR DESCRIPTION
## 概要
- Devise のパスワード再設定メール内で生成されるリンクにホストが入らず、Missing host to link to! が発生していたため、本番環境で正しい絶対 URL を生成できるようにしました。

## 変更点
- 環境変数の導入
  - APP_HOST=quotecanvas.onrender.com
  - APP_PROTOCOL=https
  - （Render の環境変数パネルで設定）
- production 設定の追加（config/environments/production.rb）
  - config.action_mailer.default_url_options に host/protocol を設定
  - Rails.application.routes.default_url_options にも同値を設定（*_url 生成の安全性向上）
  - メール内で画像等の絶対パスが必要な場合に備え、config.action_mailer.asset_host を設定
- 環境変数名の誤りを修正
  - RAILS_MAX_THREADSValue → RAILS_MAX_THREADS にリネーム