### PR TITLE
パスワード再設定フラグ制御

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,13 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  private
+
+  # サインアップ時は従来どおり
+  def sign_up_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  # アカウント更新時：MVPでは email を更新不可にする（受け取らない）
+  def account_update_params
+    params.require(:user).permit(:name, :password, :password_confirmation, :current_password)
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,5 +1,4 @@
-<!-- 背景 -->
-<div class="fixed inset-0 -z-10 gh-sky">
+<div class="fixed inset-0 -z-10 gh-sky" aria-hidden="true">
   <div class="absolute inset-0 gh-hills opacity-70"></div>
   <div class="absolute inset-0 gh-grain pointer-events-none"></div>
 </div>
@@ -29,16 +28,19 @@
         </div>
       <% end %>
 
-      <!-- 名前 -->
+      <!-- 名前（編集可） -->
       <div>
         <%= f.label :name, "名前", class: "block font-semibold mb-1" %>
-        <%= f.text_field :name, class: "input input-bordered w-full" %>
+        <%= f.text_field :name, class: "input input-bordered w-full", placeholder: "表示名" %>
       </div>
 
-      <!-- メール -->
+      <!-- メール（MVPでは編集不可） -->
       <div>
-        <%= f.label :email, "メールアドレス", class: "block font-semibold mb-1" %>
-        <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full" %>
+        <label class="block font-semibold mb-1">メールアドレス</label>
+        <input type="email" value="<%= resource.email %>" class="input input-bordered w-full" disabled>
+        <p class="text-xs opacity-70 mt-1">
+          メールの変更は<strong>本リリース後に対応予定</strong>です（現在は変更できません）。
+        </p>
       </div>
 
       <!-- Devise仕様: 確認用の現在パスワード -->
@@ -46,7 +48,9 @@
         <%= f.label :current_password, "現在のパスワード（確認用）", class: "block font-semibold mb-1" %>
         <%= f.password_field :current_password, autocomplete: "current-password",
                              class: "input input-bordered w-full" %>
-        <p class="text-sm opacity-70 mt-1">プロフィールを更新するには現在のパスワードが必要です。</p>
+        <p class="text-xs opacity-70 mt-1">
+          プロフィールを更新するには現在のパスワードが必要です。
+        </p>
       </div>
 
       <div class="flex gap-2">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,10 +3,12 @@
     ログイン
   </h1>
 
-  <%= form_with model: resource, url: session_path(resource_name), class: "mt-6 space-y-4 font-sans" do |f| %>
+  <%# Deviseは scope 指定が相性よい。local: true で通常POSTに %>
+  <%= form_with scope: resource_name, url: session_path(resource_name),
+                class: "mt-6 space-y-4 font-sans", local: true do |f| %>
     <div>
       <%= f.label :email, class: "label" %>
-      <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full" %>
+      <%= f.email_field :email, autofocus: true, class: "input input-bordered w-full", autocomplete: "email" %>
     </div>
 
     <div>
@@ -21,7 +23,15 @@
           <span class="label-text">ログイン状態を保持</span>
         </label>
       <% end %>
-      <%= link_to "パスワードをお忘れですか？", new_password_path(resource_name), class: "link link-primary" if devise_mapping.recoverable? %>
+
+      <%# ▼ パスワード再設定リンクは「機能フラグ」＆「ルート存在」時のみ表示 %>
+      <% pw_flag      = (Rails.configuration.x.features.password_reset_enabled rescue false) %>
+      <% route_helper = :"new_#{resource_name}_password_path" %>
+      <% if devise_mapping.recoverable? && pw_flag && main_app.respond_to?(route_helper) %>
+        <%= link_to "パスワードをお忘れですか？",
+                    main_app.send(route_helper),
+                    class: "link link-primary" %>
+      <% end %>
     </div>
 
     <%= f.submit "ログイン", class: "btn btn-primary w-full btn-press" %>

--- a/config/initializers/features.rb
+++ b/config/initializers/features.rb
@@ -1,0 +1,3 @@
+Rails.configuration.x.features = ActiveSupport::OrderedOptions.new
+Rails.configuration.x.features.password_reset_enabled =
+  ActiveModel::Type::Boolean.new.cast(ENV.fetch("PASSWORD_RESET_ENABLED", "false"))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   get "static/guide"
-  devise_for :users
+
+  #  パスワード機能をスキップ
+  devise_for :users, skip: [ :passwords ],
+             controllers: { registrations: "users/registrations" }
 
   # ヘルス/PWA
   get "up"             => "rails/health#show",  as: :rails_health_check
@@ -13,24 +16,19 @@ Rails.application.routes.draw do
   get "profile",   to: "users#show", as: :profile
 
   get "books/lookup", to: "books#lookup"
-  get "/guide", to: "static#guide", as: :guide
+  get "/guide",       to: "static#guide", as: :guide
   patch "users/hide_guide", to: "users#hide_guide"
 
   resources :users, only: [ :show ]
 
-  # 書籍検索フォーム画面
   resources :book_infos, only: [] do
-    collection do
-      get :search
-    end
+    collection { get :search }
   end
 
-  # API (残しておく)
   namespace :api do
     resources :books, only: [ :index ]
   end
 
-  # passages
   resources :passages, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     resources :thought_logs, only: [ :new, :create, :destroy ]
     resource  :customization, only: [ :new, :create, :edit, :update ],


### PR DESCRIPTION
## 変更点
- devise/sessions/new.html.erb
  - form_with を scope: resource_name＋local: true で安定化。
  - 「パスワードをお忘れですか？」リンクを 機能フラグ＋ルート存在チェックで出し分け
 devise_mapping.recoverable? && Rails.configuration.x.features.password_reset_enabled && main_app.respond_to?  (:new_user_password_path)
  - ルート呼び出しは main_app.send(...) に変更し名前衝突を回避。
- 初期化子を追加：config/initializers/features.rb
  - Rails.configuration.x.features.password_reset_enabled を追加（ENV["PASSWORD_RESET_ENABLED"] で制御、デフォルト false）。