### PR TITLE
背景を共通パーシャル化

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,24 +2,101 @@
 @tailwind components;
 @tailwind utilities;
 
-/* ---------- Base（フォント） ---------- */
+/* =========================
+   Base（フォント/タイポ/滑らかさ）
+   ========================= */
 @layer base {
   :root {
     --font-sans: "Inter", "Noto Sans JP", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
     --font-serif: "Shippori Mincho", "Hiragino Mincho ProN", "Hiragino Mincho Pro", YuMincho, "Yu Mincho", Georgia, serif;
+
+    /* Aurora / Vignette トークン（色と強度を変えたい時にここだけ触る） */
+    --aurora-cyan:  118 180 255;  /* #76b4ff */
+    --aurora-pink:  255 153 204;  /* #ff99cc */
+    --aurora-mint:  120 255 200;  /* #78ffc8 */
+    --aurora-alpha: .28;
+
+    --vignette-alpha: .14; /* 周辺減光の強さ（明るい背景なら 0.10〜0.18 目安） */
   }
+
   .font-sans { font-family: var(--font-sans); }
   .font-serif { font-family: var(--font-serif); }
-}
 
-/* ---------- Utilities（質感・装飾） ---------- */
-@layer utilities {
-  /* 空のグラデ（上：空色 → 下：生成り） */
-  .gh-sky {
-    background: radial-gradient(80% 60% at 50% 0%, #dff2ff 0%, #f6fbff 60%, #fbf7ef 100%);
+  html { -webkit-text-size-adjust: 100%; }
+
+  body {
+    font-family: var(--font-sans);
+    font-size: 16px;
+    line-height: 1.75;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
   }
 
-  /* 粒子ノイズ（軽量・画像不要） */
+  /* clamp で流体見出し（通常の h1/h2/h3 とユーティリティ両対応） */
+  h1, .text-fluid-3xl { font-size: clamp(1.75rem, 4.5vw + .25rem, 2.75rem); line-height: 1.2; }
+  h2, .text-fluid-2xl { font-size: clamp(1.375rem, 3.5vw + .2rem, 2rem);   line-height: 1.3; }
+  h3, .text-fluid-xl  { font-size: clamp(1.125rem, 2.8vw + .2rem, 1.5rem);  line-height: 1.35; }
+
+  /* フォーカス見やすく（Tailwindの ring と併用OK） */
+  :where(a, button, [tabindex]:not([tabindex="-1"])):focus-visible {
+    outline: 2px solid #94a3b8; /* slate-300-ish */
+    outline-offset: 2px;
+  }
+}
+
+/* =========================
+   Utilities（質感/装飾/操作性）
+   ========================= */
+@layer utilities {
+  /* --- 背景ベース（空色→生成りのやさしいグラデ） --- */
+  .gh-bg {
+    background:
+      radial-gradient(80% 60% at 50% 0%, #dff2ff 0%, #f6fbff 60%, #fbf7ef 100%);
+    /* 背景専用のレイヤーなのでレンダリング最適化 */
+    contain: paint;
+  }
+
+  /* --- オーロラ（重なり合うブラーの発光） --- */
+  .gh-aurora {
+    /* 複数の楕円ラジアルを重ねる。screenで下地と馴染ませる */
+    background:
+      radial-gradient(60% 50% at 20% 12%, rgba(var(--aurora-cyan) / var(--aurora-alpha)) 0 40%, transparent 45%),
+      radial-gradient(50% 45% at 80% 18%, rgba(var(--aurora-pink) / var(--aurora-alpha)) 0 35%, transparent 45%),
+      radial-gradient(55% 40% at 60% 80%, rgba(var(--aurora-mint) / var(--aurora-alpha)) 0 32%, transparent 45%);
+    mix-blend-mode: screen;
+    filter: blur(28px) saturate(1.05);
+    transform: translateZ(0); /* 合成コスト軽減ヒント */
+    animation: aurora-shift 16s ease-in-out infinite alternate;
+    will-change: transform, opacity;
+    pointer-events: none;
+  }
+  @keyframes aurora-shift {
+    0%   { transform: translate3d(-1%, -1%, 0) scale(1.02); opacity: .85; }
+    50%  { transform: translate3d(1%,  0.5%, 0) scale(1.04); opacity: .95; }
+    100% { transform: translate3d(0,   1%,   0) scale(1.00); opacity: .9; }
+  }
+
+  /* --- ビネット（周辺減光） --- */
+  .gh-vignette {
+    background:
+      radial-gradient(120% 110% at 50% 40%,
+        transparent 60%,
+        rgba(0 0 0 / calc(var(--vignette-alpha) * .7)) 80%,
+        rgba(0 0 0 / var(--vignette-alpha)) 100%);
+    pointer-events: none;
+  }
+  /* ダークモードでは少し強めに（daisyUIの .dark でもOK） */
+  @media (prefers-color-scheme: dark) {
+    .gh-vignette {
+      background:
+        radial-gradient(120% 110% at 50% 40%,
+          transparent 58%,
+          rgba(0 0 0 / calc(var(--vignette-alpha) * 1.1)) 80%,
+          rgba(0 0 0 / calc(var(--vignette-alpha) * 1.4)) 100%);
+    }
+  }
+
+  /* --- 粒子ノイズ（軽量・画像不要） --- */
   .gh-grain {
     background-image:
       radial-gradient(circle at 20% 20%, rgba(0,0,0,.04) 0 1px, transparent 1px 100%),
@@ -27,30 +104,10 @@
     background-size: 10px 10px, 8px 8px;
     mix-blend-mode: multiply;
     opacity: .6;
+    pointer-events: none;
   }
 
-  /* 生成りの紙 */
-  .gh-paper {
-    background: linear-gradient(#faf7f0, #f5efe2);
-  }
-
-  /* ガラスカード（@apply不使用：エディタ警告回避 & フォールバック） */
-  .gh-glass {
-    /* フォールバック（backdrop-filter非対応環境向け） */
-    background-color: rgba(255,255,255,0.7);
-    border: 1px solid rgba(17,24,39,0.08);
-    box-shadow:
-      0 10px 30px rgba(17,24,39,0.08),
-      inset 0 1px 0 rgba(255,255,255,0.35);
-  }
-  @supports ((-webkit-backdrop-filter: blur(18px)) or (backdrop-filter: blur(18px))) {
-    .gh-glass {
-      -webkit-backdrop-filter: blur(18px);
-      backdrop-filter: blur(18px);
-    }
-  }
-
-  /* 丘のシルエット（CSSのみ） */
+  /* --- 丘のシルエット（任意で使う時用） --- */
   .gh-hills {
     --c1: #cfe8d3; --c2: #a9d0b1; --c3: #86b594;
     background:
@@ -59,7 +116,22 @@
       radial-gradient(55% 45% at 90% 100%, var(--c3) 0 60%, transparent 61%) bottom right/60% 50% no-repeat;
   }
 
-  /* 手描き風の下線 */
+  /* --- 生成りの紙 --- */
+  .gh-paper { background: linear-gradient(#faf7f0, #f5efe2); }
+
+  /* --- ガラスカード（フォールバック → 対応環境でぼかし） --- */
+  .gh-glass {
+    background-color: rgba(255,255,255,0.7);
+    border: 1px solid rgba(17,24,39,0.08);
+    box-shadow:
+      0 10px 30px rgba(17,24,39,0.08),
+      inset 0 1px 0 rgba(255,255,255,0.35);
+  }
+  @supports ((-webkit-backdrop-filter: blur(18px)) or (backdrop-filter: blur(18px))) {
+    .gh-glass { -webkit-backdrop-filter: blur(18px); backdrop-filter: blur(18px); }
+  }
+
+  /* --- 手描き風の下線 --- */
   .gh-underline { position: relative; }
   .gh-underline::after{
     content:"";
@@ -71,7 +143,7 @@
     filter: blur(.2px);
   }
 
-  /* きらめき（控えめアニメ） */
+  /* --- きらめき（控えめアニメ） --- */
   .gh-sparkle { position: relative; }
   .gh-sparkle::after{
     content:"✦";
@@ -85,23 +157,62 @@
     60%{ transform: scale(.9) rotate(-8deg); opacity:.5; }
   }
 
-  /* ふわっと浮く */
-  .hover-float {
-    transition: transform .35s ease, box-shadow .35s ease;
-  }
-  .hover-float:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 10px 24px rgba(0,0,0,.12);
-  }
+  /* --- ふわっと浮く --- */
+  .hover-float { transition: transform .35s ease, box-shadow .35s ease; }
+  .hover-float:hover { transform: translateY(-4px); box-shadow: 0 10px 24px rgba(0,0,0,.12); }
 
-  /* やさしい風（小さく上下ゆれ） */
-  @keyframes breeze { 0%,100%{ transform: translateY(0) } 50%{ transform: translateY(-3px) } }
-  .breeze { animation: breeze 5s ease-in-out infinite; }
-
-  /* 動きを控えたいユーザー設定に配慮 */
+  /* --- 動きを控えたいユーザー設定に配慮 --- */
   @media (prefers-reduced-motion: reduce) {
     .gh-sparkle::after,
     .breeze,
-    .hover-float { animation: none !important; transition: none !important; }
+    .hover-float,
+    .gh-aurora { animation: none !important; transition: none !important; }
   }
+
+  /* =========================
+     モバイル最適化ユーティリティ
+     ========================= */
+
+  /* 改行バランス（日本語の見出し崩れ防止） */
+  .text-balance { text-wrap: balance; }
+
+  /* 読みやすい行幅に抑える（本文/説明） */
+  .content-readable { max-width: 65ch; }
+
+  /* タップ領域の最低サイズ（44pxルール） */
+  .touch-target { min-height: 44px; min-width: 44px; }
+
+  /* ノッチ/ホームバー安全域 */
+  .safe-pt { padding-top: env(safe-area-inset-top); }
+  .safe-pb { padding-bottom: env(safe-area-inset-bottom); }
+
+  /* フォーム/ボタンの足回り（daisyUIをやさしく上書き） */
+  :where(.btn){ min-height: 44px; padding-inline: 1rem; letter-spacing: .01em; }
+  :where(.input,.select,.textarea){ min-height: 44px; }
+
+  /* タッチ端末では hover 演出を無効化（誤作動防止） */
+  @media (hover: none) {
+    .hover-float:hover { transform: none; box-shadow: none; }
+  }
+
+  /* 小画面で装飾を控えめに（パフォーマンス/可読性重視） */
+  @media (max-width: 480px) {
+    .gh-grain { opacity: .35; }
+    .gh-underline::after { width: 4rem; bottom: -.3rem; }
+    .gh-glass { box-shadow: 0 8px 18px rgba(0,0,0,.08); }
+  }
+
+  /* 小画面ではガラスぼかし弱め（視認性・描画コスト） */
+  @supports ((-webkit-backdrop-filter: blur(18px)) or (backdrop-filter: blur(18px))) {
+    @media (max-width: 640px) {
+      .gh-glass { -webkit-backdrop-filter: blur(10px); backdrop-filter: blur(10px); }
+    }
+  }
+
+  /* カード本文の流体サイズ */
+  .card-text { font-size: clamp(1rem, 2.8vw + .2rem, 1.125rem); line-height: 1.7; }
+
+  /* 軽い揺れ（やさしい風）— 使う場合のみ付与 */
+  @keyframes breeze { 0%,100%{ transform: translateY(0) } 50%{ transform: translateY(-3px) } }
+  .breeze { animation: breeze 5s ease-in-out infinite; }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,17 +6,17 @@ import ColorPickerController from "./color_picker_controller";
 import HelloController       from "./hello_controller";
 import LashController        from "./lash_controller";
 import WelcomeController     from "./welcome_controller";
-import LogFormController from "./log_form_controller";
-import FlashController from "./flash_controller"
+import LogFormController     from "./log_form_controller";
+import FlashController       from "./flash_controller";
+import MenuController        from "./menu_controller";
 
 application.register("book-search",  BookSearchController);
 application.register("onboarding",   OnboardingController);
-application.register("color-picker",  ColorPickerController);
+application.register("color-picker", ColorPickerController);
 application.register("hello",        HelloController);
 application.register("lash",         LashController);
 application.register("welcome",      WelcomeController);
-application.register("log-form", LogFormController);
-application.register("flash", FlashController)
-
-// 余計な Application.start() や window.Stimulus の代入は不要
+application.register("log-form",     LogFormController);
+application.register("flash",        FlashController);
+application.register("menu",         MenuController);
 export {};

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["panel", "button"]
+
+  connect() {
+    this._onDocClick = (e) => { if (!this.element.contains(e.target)) this.close() }
+    this._onKeydown   = (e) => { if (e.key === "Escape") this.close() }
+    this._onBeforeCache = () => this.close()
+
+    document.addEventListener("click", this._onDocClick)
+    document.addEventListener("keydown", this._onKeydown)
+    document.addEventListener("turbo:before-cache", this._onBeforeCache)
+  }
+
+  disconnect() {
+    document.removeEventListener("click", this._onDocClick)
+    document.removeEventListener("keydown", this._onKeydown)
+    document.removeEventListener("turbo:before-cache", this._onBeforeCache)
+  }
+
+  toggle(event) {
+    event.stopPropagation()
+    if (this.isOpen()) { this.close() } else { this.open() }
+  }
+
+  open() {
+    this.panelTarget.classList.remove("hidden")
+    this.buttonTarget.setAttribute("aria-expanded", "true")
+  }
+
+  close() {
+    if (!this.isOpen()) return
+    this.panelTarget.classList.add("hidden")
+    this.buttonTarget.setAttribute("aria-expanded", "false")
+  }
+
+  isOpen() {
+    return !this.panelTarget.classList.contains("hidden")
+  }
+}

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,19 +1,24 @@
-<!-- 背景：空＋丘＋粒子 -->
-<div class="fixed inset-0 -z-10 pointer-events-none gh-sky">
-  <div class="absolute inset-0 gh-hills opacity-70"></div>
-  <div class="absolute inset-0 gh-grain"></div>
-</div>
+<%# 背景はレイアウトで一度だけ描画。ここで上書き指定 %>
+<% content_for :bg do %>
+  <%= render "shared/bg_sky",
+      class: "theme-twilight",   # ← お好みで theme-dawn / theme-midnight など
+      show_hills: true,          # ← 丘を出す
+      aurora_alpha: 0.28,        # 発光の強さ（0.18〜0.32くらいで調整）
+      vignette_alpha: 0.16,      # 周辺減光
+      grain_opacity: 0.5 %>      # 粒子
+<% end %>
 
-<div class="container mx-auto max-w-7xl px-4 md:px-8 relative z-0">
+<div class="container mx-auto max-w-7xl px-4 md:px-8 relative z-10">
   <!-- Hero：やわらかい歓迎とクイックアクション -->
-  <section class="mt-2 md:mt-4">
-    <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden hover-float">
-      <!-- 光のにじみ -->
-      <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
+  <section class="mt-2 md:mt-4" aria-labelledby="hero-title">
+    <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden isolate hover-float">
+      <!-- 光のにじみ（isolateでカード内に閉じ込め） -->
+      <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full
+                  bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
 
       <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 relative">
         <div>
-          <h1 class="text-2xl md:text-3xl font-extrabold gh-underline gh-sparkle">
+          <h1 id="hero-title" class="text-2xl md:text-3xl font-extrabold gh-underline gh-sparkle">
             こんにちは、<%= current_user.name.presence || "読者" %> さん
           </h1>
           <p class="mt-2 opacity-80">
@@ -21,18 +26,15 @@
           </p>
         </div>
         <div class="flex flex-wrap gap-2 shrink-0">
-          <%= link_to (defined?(new_passage_path) ? new_passage_path : "#"), class: "btn btn-primary breeze" do %>
+          <%= link_to new_passage_path, class: "btn btn-primary breeze" do %>
             ＋ 一節を記録
           <% end %>
 
-          <%= link_to (defined?(passages_path) ? passages_path : "#"), class: "btn btn-outline hover-float" do %>
+          <%= link_to passages_path, class: "btn btn-outline hover-float" do %>
             一覧を見る
           <% end %>
 
-          <!-- プロフィールは閲覧ページへ -->
-          <%= link_to "プロフィール", user_path(current_user), class: "btn btn-ghost hover-float" %>
-
-          <!-- 設定は別ボタンで -->
+          <%= link_to "プロフィール", profile_path, class: "btn btn-ghost hover-float" %>
           <%= link_to "アカウント設定", edit_user_registration_path, class: "btn btn-outline hover-float" %>
         </div>
       </div>
@@ -40,10 +42,10 @@
   </section>
 
   <!-- サマリ：小さな“本のカード” -->
-  <section class="mt-6 grid gap-4 sm:grid-cols-3">
+  <section class="mt-6 grid gap-4 sm:grid-cols-3" aria-label="サマリー">
     <div class="rounded-2xl gh-glass p-5 relative hover-float">
       <div class="text-sm opacity-70">あなたのカード</div>
-      <div class="text-3xl font-extrabold mt-1"><%= @passages_count %></div>
+      <div class="text-3xl font-extrabold mt-1" aria-live="polite"><%= @passages_count %></div>
     </div>
     <a href="<%= root_path %>#features" class="rounded-2xl gh-glass p-5 hover-float">
       <div class="text-sm opacity-70">カスタマイズ</div>
@@ -55,39 +57,40 @@
     <% end %>
   </section>
 
-  <!-- 最近の一節：カード棚（3列） -->
-  <section class="mt-10">
+  <!-- 最近の一節 -->
+  <section class="mt-10" aria-labelledby="recent-title">
     <div class="flex items-end justify-between">
       <div>
-        <h2 class="text-xl md:text-2xl font-bold gh-underline">最近の記録</h2>
+        <h2 id="recent-title" class="text-xl md:text-2xl font-bold gh-underline">最近の記録</h2>
         <p class="opacity-70 text-sm mt-1">直近3枚のカードをピックアップ</p>
       </div>
-      <%= link_to (defined?(passages_path) ? passages_path : "#"), class: "link link-primary" do %>
+      <%= link_to passages_path, class: "link link-primary" do %>
         すべて見る →
       <% end %>
     </div>
 
     <% if @recent_passages.any? %>
-  <div class="mt-5 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-    <% @recent_passages.each do |p| %>
-      <%= render "passages/card", passage: p, size: :mini %>
+      <div class="mt-5 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        <% @recent_passages.each do |p| %>
+          <%= render "passages/card", passage: p, size: :mini %>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="mt-6 rounded-3xl gh-glass p-10 text-center hover-float">
+        <div class="text-4xl mb-2">🌿</div>
+        <p class="font-semibold">まだカードがありません</p>
+        <p class="opacity-70 text-sm mt-1">心に残った一文を、最初の1枚に。</p>
+        <div class="mt-4">
+          <%= link_to new_passage_path, class: "btn btn-primary breeze" do %>
+            ＋ 一節を記録
+          <% end %>
+        </div>
+      </div>
     <% end %>
-  </div>
-<% else %>
-  <div class="mt-6 rounded-3xl gh-glass p-10 text-center hover-float">
-    <div class="text-4xl mb-2">🌿</div>
-    <p class="font-semibold">まだカードがありません</p>
-    <p class="opacity-70 text-sm mt-1">心に残った一文を、最初の1枚に。</p>
-    <div class="mt-4">
-      <%= link_to (defined?(new_passage_path) ? new_passage_path : "#"), class: "btn btn-primary breeze" do %>
-        ＋ 一節を記録
-      <% end %>
-    </div>
-  </div>
-<% end %>
   </section>
 
-  <section class="mt-10 grid gap-4 md:grid-cols-3">
+  <!-- 使い方の3ポイント -->
+  <section class="mt-10 grid gap-4 md:grid-cols-3" aria-label="使い方">
     <div class="rounded-2xl gh-glass p-6 hover-float">
       <div class="text-2xl">✍️</div>
       <div class="font-bold mt-2">書き留める</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,8 +1,3 @@
-<div class="fixed inset-0 -z-10 gh-sky" aria-hidden="true">
-  <div class="absolute inset-0 gh-hills opacity-70"></div>
-  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
-</div>
-
 <div class="container mx-auto max-w-3xl px-4 md:px-8 py-8 md:py-12">
   <div class="mb-6">
     <%= link_to "← 戻る", (defined?(profile_path) ? profile_path : root_path), class: "link link-primary" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,18 +2,24 @@
 <html lang="ja">
   <head>
     <meta charset="utf-8">
-    <title><%= content_for(:title) || "QuoteCanvas" %></title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title><%= content_for?(:title) ? yield(:title) : "QuoteCanvas" %></title>
+
+    <!-- 表示最適化 -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="color-scheme" content="light dark">
-    <meta name="theme-color" content="#F9FAFB">
+
+    <!-- テーマカラー（ライト/ダークで切替） -->
+    <meta name="theme-color" content="#F9FAFB" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#0B1020" media="(prefers-color-scheme: dark)">
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= yield :head %>
 
+    <!-- PWA -->
     <link rel="manifest" href="/manifest.json">
 
-    <%# フォント最適化：Interはローカル（inter-font.css）、GoogleはShipporiのみ %>
+    <%# フォント：InterはローカルCSS（app/assets/stylesheets/inter-font.css）、ShipporiはGoogle %>
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Shippori+Mincho:wght@600;700&display=swap" rel="stylesheet">
@@ -23,33 +29,46 @@
 
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
-    <style>
-      /* Turbo プログレスバーを少し見やすく */
-      .turbo-progress-bar{ height:3px; background:linear-gradient(90deg,#22d3ee,#f472b6); }
+    <%# Turbo プログレスバー（CSP nonce 付き） %>
+    <style nonce="<%= content_security_policy_nonce %>">
+      .turbo-progress-bar {
+        height: 3px;
+        background: linear-gradient(90deg, #22d3ee, #f472b6);
+      }
     </style>
   </head>
 
   <body class="min-h-dvh flex flex-col bg-base-200">
+    <!-- 背景（content_for :bg があればそっちを、無ければデフォルト背景） -->
+    <%= content_for?(:bg) ? yield(:bg) : render("shared/bg_sky") %>
+
     <!-- キーボード操作向け：コンテンツへスキップ -->
-    <a href="#main" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2
-                         focus:bg-base-100 focus:text-base-content focus:px-3 focus:py-2 focus:rounded">
+    <a href="#main"
+       class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2
+              focus:bg-base-100 focus:text-base-content focus:px-3 focus:py-2 focus:rounded">
       コンテンツへスキップ
     </a>
 
-    <%= render "shared/header" %>
-    <%= render "shared/welcome_banner" %>
+    <!-- 前面コンテンツ -->
+    <div class="relative z-10 flex min-h-0 flex-1 flex-col">
+      <%= render "shared/header" %>
+      <%= render "shared/welcome_banner" %>
 
-    <main id="main"
-          class="container mx-auto w-full max-w-7xl flex-1 px-4 md:px-8 pt-16 md:pt-20 pb-10
-                 min-h-[calc(100dvh-4rem-4rem)] md:min-h-[calc(100dvh-5rem-4rem)]
-                 [padding-bottom:env(safe-area-inset-bottom)]">
-      <%= render "shared/flash" %>
-      <%= yield %>
-    </main>
+      <main id="main" role="main"
+            class="container mx-auto w-full max-w-7xl flex-1 px-4 md:px-8 pt-16 md:pt-20 pb-10
+                   [padding-bottom:env(safe-area-inset-bottom)]">
+        <%= render "shared/flash" %>
+        <%= yield %>
+      </main>
 
-    <%= render "shared/footer" %>
-    <% if user_signed_in? && current_user.show_guide? %>
-      <%= render "shared/onboarding_modal" %>
-    <% end %>
+      <%= render "shared/footer" %>
+
+      <% if user_signed_in? && current_user.show_guide? %>
+        <%= render "shared/onboarding_modal" %>
+      <% end %>
+    </div>
+
+    <%# 追加スクリプトをページ側で挿せるように %>
+    <%= yield :body_end %>
   </body>
 </html>

--- a/app/views/shared/_bg_sky.html.erb
+++ b/app/views/shared/_bg_sky.html.erb
@@ -1,0 +1,27 @@
+<div
+  id="bg-sky"
+  class="fixed inset-0 z-0 gh-bg <%= local_assigns[:class] %>"
+  aria-hidden="true"
+  data-turbo-permanent
+  style="
+    --aurora-alpha:<%= (local_assigns[:aurora_alpha] || 0.28) %>;
+    --vignette-alpha:<%= (local_assigns[:vignette_alpha] || 0.14) %>;
+  "
+>
+  <% if local_assigns.fetch(:show_hills, false) %>
+    <div class="absolute inset-0 gh-hills opacity-70"></div>
+  <% end %>
+
+  <% if local_assigns.fetch(:show_aurora, true) %>
+    <div class="absolute inset-0 gh-aurora"></div>
+  <% end %>
+
+  <% if local_assigns.fetch(:show_vignette, true) %>
+    <div class="absolute inset-0 gh-vignette"></div>
+  <% end %>
+
+  <% if local_assigns.fetch(:show_grain, true) %>
+    <div class="absolute inset-0 gh-grain pointer-events-none"
+         style="opacity:<%= (local_assigns[:grain_opacity] || 0.6) %>;"></div>
+  <% end %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="border-t bg-base-100">
+<footer class="border-t bg-base-100/90 backdrop-blur supports-[backdrop-filter]:bg-base-100/70">
   <div class="container mx-auto max-w-6xl px-4 md:px-8 py-8 grid gap-6 md:grid-cols-3">
     <div>
       <div class="font-bold text-lg">QuoteCanvas</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,28 +1,36 @@
-<header class="sticky top-0 left-0 right-0 z-50 border-b shadow-sm
-               bg-base-100/90 backdrop-blur supports-[backdrop-filter]:bg-base-100/70">
+<header
+  class="sticky top-0 left-0 right-0 z-50 border-b shadow-sm
+         bg-base-100/95 backdrop-blur supports-[backdrop-filter]:bg-base-100/80">
+  <!-- 高さを固定（main 側の pt-16 md:pt-20 と対応させる） -->
   <div class="h-16 md:h-20">
     <div class="container mx-auto max-w-7xl h-full px-4 md:px-8
                 flex items-center justify-between gap-3 overflow-visible">
 
       <!-- 左：ブランド -->
       <%= link_to root_path,
-          class: "btn btn-ghost h-10 min-h-10 px-2 text-xl md:text-2xl font-extrabold leading-none shrink-0" do %>
+          class: "btn btn-ghost h-10 min-h-10 px-2 text-xl md:text-2xl font-extrabold leading-none shrink-0",
+          aria: { label: "トップへ" } do %>
         QuoteCanvas
       <% end %>
+
+      <%# トップ以外からでも #features に確実に飛べるようにする %>
+      <% features_href = current_page?(root_path) ? "#features" : root_path(anchor: "features") %>
 
       <!-- 中央：PCナビ -->
       <nav class="hidden lg:flex flex-1 min-w-0 justify-center">
         <ul class="menu menu-horizontal px-1 items-center truncate">
           <li>
-            <%= link_to "機能", "#{root_path}#features",
-                class: "px-3 h-10 leading-none hover:underline underline-offset-8 #{current_page?(root_path) ? 'font-semibold underline' : ''}",
-                aria: { current: current_page?(root_path) ? 'page' : nil } %>
+            <a href="<%= features_href %>"
+               class="px-3 h-10 leading-none hover:underline underline-offset-8 <%= controller_name == 'top' ? 'font-semibold underline' : '' %>">
+              機能
+            </a>
           </li>
           <li>
             <%= link_to "使い方", guide_path,
-                class: "px-3 h-10 leading-none hover:underline underline-offset-8 #{current_page?(guide_path) ? 'font-semibold underline' : ''}",
-                aria: { current: current_page?(guide_path) ? 'page' : nil } %>
+                class: "px-3 h-10 leading-none hover:underline underline-offset-8 #{controller_name == 'static' && action_name == 'guide' ? 'font-semibold underline' : ''}",
+                aria: { current: (controller_name == 'static' && action_name == 'guide') ? 'page' : nil } %>
           </li>
+
           <% if user_signed_in? %>
             <li>
               <%= link_to "ダッシュボード", dashboard_path,
@@ -35,7 +43,6 @@
 
       <!-- 右：アクション -->
       <div class="flex items-center gap-2 shrink-0">
-
         <% if user_signed_in? %>
           <!-- クイック作成（SM以上で表示） -->
           <%= link_to "＋ 一節を記録", new_passage_path,
@@ -43,15 +50,14 @@
 
           <!-- モバイルメニュー（ハンバーガー） -->
           <div class="dropdown dropdown-end lg:hidden">
-            <div tabindex="0" role="button" class="btn btn-ghost h-10 min-h-10 px-3" aria-haspopup="menu">
-              ☰
-            </div>
-            <ul tabindex="0" class="menu dropdown-content z-[60] p-2 shadow bg-base-100 rounded-box w-56 mt-2">
+            <button tabindex="0" class="btn btn-ghost h-10 min-h-10 px-3" aria-label="メニューを開く">☰</button>
+            <ul tabindex="0"
+                class="menu menu-sm dropdown-content z-[60] mt-2 p-2 shadow bg-base-100 rounded-box w-56">
               <li><%= link_to "ダッシュボード", dashboard_path %></li>
               <li><%= link_to "＋ 一節を記録", new_passage_path %></li>
+              <li class="menu-title mt-1">アカウント</li>
               <li><%= link_to "プロフィール", profile_path %></li>
               <li><%= link_to "アカウント設定", edit_user_registration_path %></li>
-              <li class="menu-title mt-1">その他</li>
               <li>
                 <%= link_to "ログアウト", destroy_user_session_path,
                       data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" } %>
@@ -61,17 +67,18 @@
 
           <!-- ユーザードロップダウン（PC） -->
           <div class="dropdown dropdown-end hidden lg:block">
-            <div tabindex="0" role="button" class="btn btn-ghost h-10 min-h-10 px-3" aria-haspopup="menu">
+            <button tabindex="0" class="btn btn-ghost h-10 min-h-10 px-3" aria-haspopup="menu">
               <span class="hidden md:inline mr-2 truncate max-w-[10rem]">
                 <%= current_user.name.presence || "ユーザー" %>
               </span>
               <div class="avatar placeholder">
                 <div class="bg-neutral text-neutral-content rounded-full w-8">
-                  <span><%= (current_user.name.presence || current_user.email).to_s.first.upcase %></span>
+                  <span><%= (current_user.name.presence || current_user.email).to_s.first&.upcase %></span>
                 </div>
               </div>
-            </div>
-            <ul tabindex="0" class="menu dropdown-content z-[60] p-2 shadow bg-base-100 rounded-box w-56 mt-2">
+            </button>
+            <ul tabindex="0"
+                class="menu menu-sm dropdown-content z-[60] mt-2 p-2 shadow bg-base-100 rounded-box w-56">
               <li><%= link_to "ダッシュボード", dashboard_path %></li>
               <li><%= link_to "＋ 一節を記録", new_passage_path %></li>
               <li><%= link_to "プロフィール", profile_path %></li>
@@ -82,10 +89,11 @@
               </li>
             </ul>
           </div>
-
         <% else %>
-          <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost h-10 min-h-10 px-3" %>
-          <%= link_to "はじめる", new_user_registration_path, class: "btn btn-primary h-10 min-h-10 px-4" %>
+          <%= link_to "ログイン", new_user_session_path,
+              class: "btn btn-ghost h-10 min-h-10 px-3" %>
+          <%= link_to "はじめる", new_user_registration_path,
+              class: "btn btn-primary h-10 min-h-10 px-4" %>
         <% end %>
       </div>
 

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,71 +1,78 @@
-<!-- 背景：空＋丘＋粒子（粒子はポインタイベント無効） -->
-<div class="fixed inset-0 -z-10 gh-sky" aria-hidden="true">
-  <div class="absolute inset-0 gh-hills opacity-70"></div>
-  <div class="absolute inset-0 gh-grain pointer-events-none"></div>
-</div>
-
-<section class="pt-10 md:pt-12">
+<section class="pt-8 sm:pt-10 md:pt-12">
   <div class="container mx-auto max-w-7xl px-4 md:px-8">
 
     <!-- Hero -->
-    <div class="rounded-3xl gh-glass p-8 md:p-10 relative overflow-hidden hover-float">
+    <div class="rounded-3xl gh-glass p-6 sm:p-8 md:p-10 relative overflow-hidden hover-float">
       <!-- 光のにじみ：モバイルは非表示で軽量化 -->
       <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl hidden md:block"></div>
 
-      <div class="grid items-center gap-10 lg:grid-cols-2">
+      <div class="grid items-center gap-8 sm:gap-10 lg:grid-cols-2">
+        <!-- 左：コピー & CTA -->
         <div>
           <div class="flex items-center gap-2 mb-3">
             <span class="badge badge-primary">MVP</span>
             <span class="badge badge-ghost">プライバシー重視</span>
           </div>
-          <h1 class="font-serif text-4xl md:text-5xl tracking-tight gh-underline gh-sparkle">
+
+          <h1 class="font-serif text-fluid-3xl tracking-tight gh-underline gh-sparkle">
             一節が、記憶になる。
           </h1>
-          <p class="mt-4 text-base md:text-lg opacity-85 font-sans">
+
+          <p class="mt-4 text-[15px] sm:text-base md:text-lg opacity-85 font-sans content-readable">
             心に刺さった一節を、<b>著者・タイトル</b>と一緒に保存。<br>
             背景・文字色・フォントを<b>自分らしくカスタム</b>して、“言葉のカード”としてコレクション。<br>
             <span class="opacity-80">思考ログで「言葉 → 気づき」の連鎖も辿れます。</span>
           </p>
 
-          <div class="mt-8 flex flex-col sm:flex-row gap-3">
+          <div class="mt-6 sm:mt-8 flex flex-col sm:flex-row gap-3">
             <% if user_signed_in? %>
-              <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-primary btn-press" %>
-              <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-outline btn-press underline-grow" %>
+              <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-primary btn-press tap-target" %>
+              <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-outline btn-press underline-grow tap-target" %>
             <% else %>
-              <%= link_to "無料ではじめる", new_user_registration_path, class: "btn btn-primary btn-press" %>
-              <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-press underline-grow" %>
+              <%= link_to "無料ではじめる", new_user_registration_path, class: "btn btn-primary btn-press tap-target" %>
+              <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-press underline-grow tap-target" %>
             <% end %>
           </div>
           <p class="mt-3 text-xs opacity-60 font-sans">登録は1分。広告なし・いつでも削除できます。</p>
         </div>
 
-        <!-- プレビュー（紙カード風）：高さ安定＆装飾は控えめ -->
+        <!-- 右：プレビュー（紙カード風） -->
         <div class="max-w-lg mx-auto w-full">
-          <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden">
-            <div class="grid gap-5">
-              <div class="relative rounded-2xl p-6 border gh-paper">
+          <div class="rounded-3xl gh-glass p-4 sm:p-6 md:p-8 relative overflow-hidden">
+            <div class="grid gap-4 sm:gap-5">
+              <!-- 大きめカード（1列固定） -->
+              <div class="relative rounded-2xl p-5 sm:p-6 border gh-paper overflow-hidden">
                 <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
                 <div class="text-[11px] opacity-70 mb-1 font-sans">夏目 漱石『こころ』</div>
-                <div class="text-xl md:text-2xl font-semibold leading-relaxed font-serif">
+                <div class="card-text font-semibold font-serif text-balance break-words">
                   「人は弱い。弱さを知るところから、やさしさが始まる。」
                 </div>
               </div>
 
-              <div class="grid grid-cols-2 gap-4">
-                <!-- Unknown を太宰 治に置換（PD） -->
-                <div class="relative rounded-2xl p-4 border" style="background:#111827; color:#F9FAFB; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;">
+              <!-- 小さめカード：モバイル1列 / SM以上2列、等高化 -->
+              <div class="grid auto-rows-fr gap-3 sm:gap-4 sm:grid-cols-2">
+                <div
+                  class="relative rounded-2xl p-4 border overflow-hidden"
+                  style="background:#111827; color:#F9FAFB; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;"
+                >
                   <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl opacity-40"></div>
                   <div class="text-[10px] opacity-70 mb-1">太宰 治『走れメロス』</div>
-                  <div class="text-sm font-semibold">メロスは激怒した。</div>
+                  <div class="text-sm font-semibold break-words">メロスは激怒した。</div>
                 </div>
-                <div class="relative rounded-2xl p-4 border gh-paper" style="color:#065F46; font-family: var(--font-sans);">
+
+                <div
+                  class="relative rounded-2xl p-4 border gh-paper overflow-hidden"
+                  style="color:#065F46; font-family: var(--font-sans);"
+                >
                   <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
                   <div class="text-[10px] opacity-70 mb-1">川端 康成『雪国』</div>
-                  <div class="text-sm font-semibold">国境の長いトンネルを抜けると雪国であった。</div>
+                  <div class="text-sm font-semibold break-words">国境の長いトンネルを抜けると雪国であった。</div>
                 </div>
               </div>
 
-              <p class="text-xs opacity-60 font-sans">* 入力内容に合わせてバランスよくレイアウトされます</p>
+              <p class="text-xs opacity-60 font-sans content-readable mx-auto">
+                * 入力内容に合わせてバランスよくレイアウトされます
+              </p>
             </div>
           </div>
         </div>
@@ -73,55 +80,55 @@
     </div>
 
     <!-- How it works（3ステップ） -->
-    <section id="how" class="scroll-mt-24 py-12 md:py-14">
-      <h2 class="text-2xl md:text-3xl font-bold text-center font-serif gh-underline">使い方はシンプル</h2>
+    <section id="how" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
+      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">使い方はシンプル</h2>
       <p class="text-center opacity-70 mt-2 font-sans">5分で “あなたの本棚” ができあがる</p>
 
-      <div class="mt-8 grid gap-4 md:grid-cols-3">
+      <div class="mt-8 grid gap-4 sm:gap-5 md:grid-cols-3">
         <%[
           {n:"1", title:"一節を入力", body:"本文・著者・タイトルをサッと記録"},
           {n:"2", title:"書誌を補完", body:"「書籍を検索」で書影や出版情報を取得"},
           {n:"3", title:"彩って保存", body:"背景・文字色・フォントを選んでカード化"}
         ].each do |s| %>
-          <div class="rounded-2xl gh-glass p-6 hover-float">
+          <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
             <div class="size-8 rounded-full bg-base-300 flex items-center justify-center font-bold"><%= s[:n] %></div>
             <h3 class="mt-3 font-bold text-lg font-sans"><%= s[:title] %></h3>
-            <p class="opacity-80 mt-1 text-sm font-sans"><%= s[:body] %></p>
+            <p class="opacity-80 mt-1 text-sm font-sans content-readable"><%= s[:body] %></p>
           </div>
         <% end %>
       </div>
 
       <div class="mt-6 text-center">
-        <%= link_to "詳しい使い方を見る →", guide_path, class: "link link-primary" %>
+        <%= link_to "詳しい使い方を見る →", guide_path, class: "link link-primary tap-target" %>
       </div>
     </section>
 
     <!-- Features -->
-    <section id="features" class="scroll-mt-24 py-12 md:py-14">
-      <h2 class="text-2xl md:text-3xl font-bold text-center font-serif gh-underline">QuoteCanvas の特徴</h2>
+    <section id="features" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
+      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">QuoteCanvas の特徴</h2>
       <p class="text-center opacity-70 mt-2 font-sans">“続けたくなる理由”がここに</p>
 
-      <div class="mt-8 grid gap-6 md:grid-cols-3">
+      <div class="mt-8 grid gap-5 sm:gap-6 md:grid-cols-3">
         <%[
           {icon:"📌", title:"秒速で記録",  body:"忘れないうちに保存。最低限の入力でOK。"},
           {icon:"🧠", title:"思考ログ",    body:"気づきや連想を時系列に残し、後で辿れる。"},
           {icon:"🎨", title:"カードとして美しい", body:"色・フォントを自由に。眺める体験が楽しい。"}
         ].each do |f| %>
-          <div class="rounded-2xl gh-glass p-6 hover-float">
+          <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
             <div class="text-3xl"><%= f[:icon] %></div>
             <h3 class="mt-3 font-bold text-xl font-sans"><%= f[:title] %></h3>
-            <p class="opacity-80 mt-2 text-sm font-sans"><%= f[:body] %></p>
+            <p class="opacity-80 mt-2 text-sm font-sans content-readable"><%= f[:body] %></p>
           </div>
         <% end %>
       </div>
     </section>
 
     <!-- Gallery -->
-    <section id="gallery" class="scroll-mt-24 py-12 md:py-14">
-      <h2 class="text-2xl md:text-3xl font-bold text-center font-serif gh-underline">カード・ギャラリー</h2>
+    <section id="gallery" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
+      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">カード・ギャラリー</h2>
       <p class="text-center opacity-70 mt-2 font-sans">“言葉の表情”は、色とフォントで変わる</p>
 
-      <div class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="mt-8 grid gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         <% samples = [
           {bg:"#FDF2F8", fg:"#4A044E", font:"var(--font-serif)",    meta:"与謝野晶子『みだれ髪』", body:"その手をば柔らかにして我に触れよ"},
           {bg:"#111827", fg:"#F9FAFB", font:"ui-monospace,SFMono-Regular,Menlo,monospace", meta:"太宰 治『走れメロス』", body:"メロスは激怒した。"},
@@ -131,49 +138,51 @@
           {bg:"#F3F4F6", fg:"#111827", font:"var(--font-serif)",     meta:"宮沢 賢治『雨ニモマケズ』", body:"雨ニモマケズ 風ニモマケズ"}
         ] %>
         <% samples.each do |c| %>
-          <div class="relative rounded-2xl p-6 border"
+          <div class="relative rounded-2xl p-5 sm:p-6 border overflow-hidden"
                style="background:<%= c[:bg] %>; color:<%= c[:fg] %>; font-family:<%= c[:font] %>;">
             <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
             <div class="text-[11px] opacity-70 mb-1 font-sans"><%= c[:meta] %></div>
-            <div class="text-lg font-semibold leading-relaxed"><%= c[:body] %></div>
+            <div class="text-base sm:text-lg font-semibold leading-relaxed break-words"><%= c[:body] %></div>
           </div>
         <% end %>
       </div>
     </section>
 
     <!-- Roadmap -->
-    <section id="roadmap" class="scroll-mt-24 py-12 md:py-14">
-      <h2 class="text-2xl md:text-3xl font-bold text-center font-serif gh-underline">これから</h2>
+    <section id="roadmap" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
+      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">これから</h2>
       <p class="text-center opacity-70 mt-2 font-sans">MVP後に予定しているアップデート</p>
 
-      <div class="mt-8 grid gap-6 md:grid-cols-3">
+      <div class="mt-8 grid gap-5 sm:gap-6 md:grid-cols-3">
         <%[
           {title:"テーマ切替", body:"気分でダーク／ライトや配色テーマを選択。"},
           {title:"タグと検索", body:"タグ付けとキーワードで、欲しい一節を素早く発見。"},
           {title:"タグ機能の強化", body:"おすすめタグ・一括編集・並び替えで整理しやすく。"}
         ].each do |f| %>
-          <div class="rounded-2xl gh-glass p-6 hover-float">
+          <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
             <h3 class="font-bold text-xl font-sans"><%= f[:title] %></h3>
-            <p class="opacity-80 mt-2 text-sm font-sans"><%= f[:body] %></p>
+            <p class="opacity-80 mt-2 text-sm font-sans content-readable"><%= f[:body] %></p>
           </div>
         <% end %>
       </div>
     </section>
 
     <!-- CTA -->
-    <section class="py-12 md:py-14">
-      <div class="rounded-3xl bg-gradient-to-r from-primary to-secondary text-primary-content p-8 md:p-10 text-center shadow-xl hover-float">
-        <h2 class="font-serif text-3xl md:text-4xl font-extrabold tracking-tight">さぁ、一節をカードにしよう。</h2>
+    <section class="py-10 sm:py-12 md:py-14">
+      <div class="rounded-3xl bg-gradient-to-r from-primary to-secondary text-primary-content p-6 sm:p-8 md:p-10 text-center shadow-xl hover-float">
+        <h2 class="font-serif text-3xl md:text-4xl font-extrabold tracking-tight text-balance">さぁ、一節をカードにしよう。</h2>
         <p class="mt-2 opacity-90 font-sans">言葉を集める。自分の色で、記憶にする。</p>
+
         <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
           <% if user_signed_in? %>
-            <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-secondary btn-press" %>
-            <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-ghost btn-press underline-grow" %>
+            <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-secondary btn-press tap-target" %>
+            <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-ghost btn-press underline-grow tap-target" %>
           <% else %>
-            <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-secondary btn-press" %>
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost btn-press underline-grow" %>
+            <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-secondary btn-press tap-target" %>
+            <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost btn-press underline-grow tap-target" %>
           <% end %>
         </div>
+
         <p class="mt-3 text-xs opacity-80 font-sans">データはあなた専用。共有は任意です。</p>
       </div>
     </section>


### PR DESCRIPTION
## 概要
- 背景実装をページ内div直書きから共有パーシャル化して再利用しやすくしました。
- ヒーロー/カードのレイヤー安定化（z-index/スタッキング文脈）と見た目の一貫性をアップしました。
- モバイルでのチラつき（Turbo遷移）を抑制しました。

## 変更点
- app/views/shared/_bg_sky.html.erb を拡張
  - Aurora/Vignette/Grain に加えて 丘（gh-hills） を出せる show_hills オプションを追加
  - 強さ調整のローカル変数：aurora_alpha / vignette_alpha / grain_opacity
  - 表示切替：show_aurora / show_vignette / show_grain / show_hills
  - 安定化：id="bg-sky", data-turbo-permanent, z-0 に統一
- レイアウト側で背景を1回だけ描画できるように（既に導入済みの content_for :bg を利用）
- トップページ（このPR対象ビュー）で content_for :bg を使ってパーシャル呼び出し
  - 例：class: "theme-twilight", show_hills: true, aurora_alpha: 0.28, vignette_alpha: 0.16, grain_opacity: 0.5
- 既存のページ直書き背景 <div class="fixed ..."> は削除
- ヒーローカードに isolate を付与して内側の光のにじみが溢れないように調整
- 前面コンテナは relative z-10、背景は z-0 に整理（-z-10 は排除）
- （軽微）リンク先とARIA属性の整理：profile_path など