### PR TITLE
ページ機能の調整

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -10,17 +10,14 @@
     --font-sans: "Inter", "Noto Sans JP", system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
     --font-serif: "Shippori Mincho", "Hiragino Mincho ProN", "Hiragino Mincho Pro", YuMincho, "Yu Mincho", Georgia, serif;
 
-    /* Aurora / Vignette トークン（色と強度を変えたい時にここだけ触る） */
+    /* Aurora / Vignette トークン */
     --aurora-cyan:  118 180 255;  /* #76b4ff */
     --aurora-pink:  255 153 204;  /* #ff99cc */
     --aurora-mint:  120 255 200;  /* #78ffc8 */
     --aurora-alpha: .28;
 
-    --vignette-alpha: .14; /* 周辺減光の強さ（明るい背景なら 0.10〜0.18 目安） */
+    --vignette-alpha: .14; /* 0.10〜0.18 目安 */
   }
-
-  .font-sans { font-family: var(--font-sans); }
-  .font-serif { font-family: var(--font-serif); }
 
   html { -webkit-text-size-adjust: 100%; }
 
@@ -32,7 +29,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  /* clamp で流体見出し（通常の h1/h2/h3 とユーティリティ両対応） */
+  /* 流体見出し */
   h1, .text-fluid-3xl { font-size: clamp(1.75rem, 4.5vw + .25rem, 2.75rem); line-height: 1.2; }
   h2, .text-fluid-2xl { font-size: clamp(1.375rem, 3.5vw + .2rem, 2rem);   line-height: 1.3; }
   h3, .text-fluid-xl  { font-size: clamp(1.125rem, 2.8vw + .2rem, 1.5rem);  line-height: 1.35; }
@@ -52,20 +49,18 @@
   .gh-bg {
     background:
       radial-gradient(80% 60% at 50% 0%, #dff2ff 0%, #f6fbff 60%, #fbf7ef 100%);
-    /* 背景専用のレイヤーなのでレンダリング最適化 */
-    contain: paint;
+    contain: paint; /* 背景専用レイヤーでレンダリング最適化 */
   }
 
-  /* --- オーロラ（重なり合うブラーの発光） --- */
+  /* --- オーロラ --- */
   .gh-aurora {
-    /* 複数の楕円ラジアルを重ねる。screenで下地と馴染ませる */
     background:
-      radial-gradient(60% 50% at 20% 12%, rgba(var(--aurora-cyan) / var(--aurora-alpha)) 0 40%, transparent 45%),
-      radial-gradient(50% 45% at 80% 18%, rgba(var(--aurora-pink) / var(--aurora-alpha)) 0 35%, transparent 45%),
-      radial-gradient(55% 40% at 60% 80%, rgba(var(--aurora-mint) / var(--aurora-alpha)) 0 32%, transparent 45%);
+      radial-gradient(60% 50% at 20% 12%, rgb(var(--aurora-cyan) / var(--aurora-alpha)) 0 40%, transparent 45%),
+      radial-gradient(50% 45% at 80% 18%, rgb(var(--aurora-pink) / var(--aurora-alpha)) 0 35%, transparent 45%),
+      radial-gradient(55% 40% at 60% 80%, rgb(var(--aurora-mint) / var(--aurora-alpha)) 0 32%, transparent 45%);
     mix-blend-mode: screen;
     filter: blur(28px) saturate(1.05);
-    transform: translateZ(0); /* 合成コスト軽減ヒント */
+    transform: translateZ(0);
     animation: aurora-shift 16s ease-in-out infinite alternate;
     will-change: transform, opacity;
     pointer-events: none;
@@ -81,18 +76,17 @@
     background:
       radial-gradient(120% 110% at 50% 40%,
         transparent 60%,
-        rgba(0 0 0 / calc(var(--vignette-alpha) * .7)) 80%,
-        rgba(0 0 0 / var(--vignette-alpha)) 100%);
+        rgb(0 0 0 / calc(var(--vignette-alpha) * .7)) 80%,
+        rgb(0 0 0 / var(--vignette-alpha)) 100%);
     pointer-events: none;
   }
-  /* ダークモードでは少し強めに（daisyUIの .dark でもOK） */
   @media (prefers-color-scheme: dark) {
     .gh-vignette {
       background:
         radial-gradient(120% 110% at 50% 40%,
           transparent 58%,
-          rgba(0 0 0 / calc(var(--vignette-alpha) * 1.1)) 80%,
-          rgba(0 0 0 / calc(var(--vignette-alpha) * 1.4)) 100%);
+          rgb(0 0 0 / calc(var(--vignette-alpha) * 1.1)) 80%,
+          rgb(0 0 0 / calc(var(--vignette-alpha) * 1.4)) 100%);
     }
   }
 
@@ -107,7 +101,7 @@
     pointer-events: none;
   }
 
-  /* --- 丘のシルエット（任意で使う時用） --- */
+  /* --- 丘のシルエット（任意） --- */
   .gh-hills {
     --c1: #cfe8d3; --c2: #a9d0b1; --c3: #86b594;
     background:
@@ -119,8 +113,7 @@
   /* --- 生成りの紙 --- */
   .gh-paper { background: linear-gradient(#faf7f0, #f5efe2); }
 
-  /* --- ガラスカード（フォールバック → 対応環境でぼかし）
-       ※ gh-surface も同じ見た目にして共用 --- */
+  /* --- ガラス/サーフェス --- */
   .gh-glass,
   .gh-surface {
     background-color: rgba(255,255,255,0.7);
@@ -133,6 +126,8 @@
     .gh-glass,
     .gh-surface { -webkit-backdrop-filter: blur(18px); backdrop-filter: blur(18px); }
   }
+  /* 明るい面では常にテーマの文字色を使う（白抜け防止） */
+  .gh-surface { @apply text-base-content; }
 
   /* --- 手描き風の下線 --- */
   .gh-underline { position: relative; }
@@ -146,7 +141,7 @@
     filter: blur(.2px);
   }
 
-  /* --- きらめき（控えめアニメ） --- */
+  /* --- きらめき --- */
   .gh-sparkle { position: relative; }
   .gh-sparkle::after{
     content:"✦";
@@ -164,7 +159,7 @@
   .hover-float { transition: transform .35s ease, box-shadow .35s ease; }
   .hover-float:hover { transform: translateY(-4px); box-shadow: 0 10px 24px rgba(0,0,0,.12); }
 
-  /* --- 動きを控えたいユーザー設定に配慮 --- */
+  /* 動きを控えたいユーザー設定に配慮 */
   @media (prefers-reduced-motion: reduce) {
     .gh-sparkle::after,
     .breeze,
@@ -179,13 +174,13 @@
   /* 改行バランス（日本語の見出し崩れ防止） */
   .text-balance { text-wrap: balance; }
 
-  /* 読みやすい行幅に抑える（本文/説明） */
+  /* 読みやすい行幅（本文/説明） */
   .content-readable { max-width: 65ch; }
 
-  /* タップ領域の最低サイズ（44pxルール） */
+  /* タップ領域（44pxルール） */
   .touch-target { min-height: 44px; min-width: 44px; }
 
-  /* ノッチ/ホームバー安全域 */
+  /* ノッチ/ホームバー */
   .safe-pt { padding-top: env(safe-area-inset-top); }
   .safe-pb { padding-bottom: env(safe-area-inset-bottom); }
 
@@ -193,12 +188,12 @@
   :where(.btn){ min-height: 44px; padding-inline: 1rem; letter-spacing: .01em; }
   :where(.input,.select,.textarea){ min-height: 44px; }
 
-  /* タッチ端末では hover 演出を無効化（誤作動防止） */
+  /* タッチ端末では hover 無効化 */
   @media (hover: none) {
     .hover-float:hover { transform: none; box-shadow: none; }
   }
 
-  /* 小画面で装飾を控えめに（パフォーマンス/可読性重視） */
+  /* 小画面で装飾控えめ */
   @media (max-width: 480px) {
     .gh-grain { opacity: .35; }
     .gh-underline::after { width: 4rem; bottom: -.3rem; }
@@ -206,7 +201,7 @@
     .gh-surface { box-shadow: 0 8px 18px rgba(0,0,0,.08); }
   }
 
-  /* 小画面ではガラスぼかし弱め（視認性・描画コスト） */
+  /* 小画面ではガラスぼかし弱め */
   @supports ((-webkit-backdrop-filter: blur(18px)) or (backdrop-filter: blur(18px))) {
     @media (max-width: 640px) {
       .gh-glass,
@@ -217,12 +212,25 @@
   /* カード本文の流体サイズ */
   .card-text { font-size: clamp(1rem, 2.8vw + .2rem, 1.125rem); line-height: 1.7; }
 
-  /* 軽い揺れ（やさしい風）— 使う場合のみ付与 */
+  /* やさしい風 */
   @keyframes breeze { 0%,100%{ transform: translateY(0) } 50%{ transform: translateY(-3px) } }
   .breeze { animation: breeze 5s ease-in-out infinite; }
-}
 
-/* === 追加：明るい面では常にテーマの文字色を使う（白抜け防止） === */
-@layer utilities {
-  .gh-surface { @apply text-base-content; }
+  /* ============ カード高さユーティリティ ============ */
+  /* 一覧カード等に使う高さ（安定レイアウト用） */
+  .card-h { height: 168px; }          /* ~640px未満 */
+  @screen sm { .card-h { height: 184px; } }  /* ≥640px */
+  @screen lg { .card-h { height: 192px; } }  /* ≥1024px */
+
+  /* プレイグラウンドの #demo-card 専用（少しだけ低め） */
+  .qc-demo-h { height: 135px; }             /* ~640px未満 */
+  @screen sm { .qc-demo-h { height: 150px; } }  /* ≥640px */
+  @screen lg { .qc-demo-h { height: 140px; } }  /* ≥1024px */
+
+  /* 行数制限（プラグイン不要） */
+  .clamp-2 { display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+  .clamp-3 { display:-webkit-box; -webkit-line-clamp:3; -webkit-box-orient:vertical; overflow:hidden; }
+
+  /* status ドット */
+  .status { @apply mt-1 inline-block w-2.5 h-2.5 rounded-full bg-primary opacity-90 flex-none; }
 }

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,87 +1,122 @@
-<%# 背景はレイアウトで一度だけ描画。ここで上書き指定 %>
+<%# =========================
+    背景（トップと統一／少しだけきらびやか）
+    ========================= %>
 <% content_for :bg do %>
   <%= render "shared/bg_sky",
-      class: "theme-twilight",   # ← お好みで theme-dawn / theme-midnight など
-      show_hills: true,          # ← 丘を出す
-      aurora_alpha: 0.28,        # 発光の強さ（0.18〜0.32くらいで調整）
-      vignette_alpha: 0.16,      # 周辺減光
-      grain_opacity: 0.5 %>      # 粒子
+      class: "theme-twilight",
+      show_hills: true,
+      aurora_alpha: 0.30,
+      vignette_alpha: 0.16,
+      grain_opacity: 0.5 %>
 <% end %>
 
-<div class="container mx-auto max-w-7xl px-4 md:px-8 relative z-10">
-  <!-- Hero：やわらかい歓迎とクイックアクション -->
+<div class="container mx-auto max-w-7xl px-4 md:px-8 relative z-10 w-full overflow-x-hidden">
+  <!-- ========== Hero：物語の扉（光ときらめき） ========== -->
   <section class="mt-2 md:mt-4" aria-labelledby="hero-title">
-    <div class="rounded-3xl gh-glass p-6 md:p-8 relative overflow-hidden isolate hover-float">
-      <!-- 光のにじみ（isolateでカード内に閉じ込め） -->
-      <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full
-                  bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl"></div>
+    <div class="rounded-3xl gh-glass p-5 sm:p-6 md:p-8 relative overflow-hidden isolate hover-float">
+      <!-- やわらかな光のオーブ -->
+      <div aria-hidden="true" class="qc-orb qc-orb-1"></div>
+      <div aria-hidden="true" class="qc-orb qc-orb-2"></div>
+      <!-- ほのかなホタル -->
+      <div aria-hidden="true" class="qc-fireflies">
+        <% 10.times do %><span></span><% end %>
+      </div>
 
-      <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 relative">
-        <div>
-          <h1 id="hero-title" class="text-2xl md:text-3xl font-extrabold gh-underline gh-sparkle">
-            こんにちは、<%= current_user.name.presence || "読者" %> さん
+      <div class="flex flex-col md:flex-row items-start md:items-center justify-between gap-6 relative min-w-0">
+        <div class="min-w-0">
+          <h1 id="hero-title" class="text-2xl md:text-3xl font-extrabold gh-underline gh-sparkle truncate">
+            こんにちは、<%= (current_user.name.presence || "読者") %> さん
           </h1>
-          <p class="mt-2 opacity-80">
-            風のようにすっと書き留めて、森の本棚にそっと並べよう。
+          <p class="mt-2 opacity-80 text-sm sm:text-base">
+            心に刺さった一節を、色とフォントで“小さな作品”にして並べよう。
           </p>
+
+          <!-- バッジ的ミニ統計 -->
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <span class="badge badge-primary">
+              カード <span class="ml-1" data-countup="<%= @passages_count.to_i %>"><%= @passages_count %></span>
+            </span>
+            <% if defined?(@streak) && @streak.to_i > 0 %>
+              <span class="badge badge-ghost">連続 <%= @streak %> 日</span>
+            <% end %>
+            <span class="badge badge-ghost">広告なし</span>
+            <span class="badge badge-ghost">プライバシー重視</span>
+          </div>
         </div>
+
+        <!-- クイックアクション -->
         <div class="flex flex-wrap gap-2 shrink-0">
-          <%= link_to new_passage_path, class: "btn btn-primary breeze" do %>
+          <%= link_to new_passage_path, class: "btn btn-primary breeze", data: { confetti: true } do %>
             ＋ 一節を記録
           <% end %>
-
           <%= link_to passages_path, class: "btn btn-outline hover-float" do %>
             一覧を見る
           <% end %>
-
           <%= link_to "プロフィール", profile_path, class: "btn btn-ghost hover-float" %>
-          <%= link_to "アカウント設定", edit_user_registration_path, class: "btn btn-outline hover-float" %>
+          <%= link_to "設定", edit_user_registration_path, class: "btn btn-outline hover-float" %>
+        </div>
+      </div>
+
+      <!-- 小さな“下書きカード”ティザー（クリックで作成へ） -->
+      <div class="mt-5 rounded-2xl border overflow-hidden gh-surface p-4 sm:p-5 hover-float cursor-pointer"
+           onclick="window.location.href='<%= new_passage_path %>'" role="button" aria-label="一節を下書きする">
+        <div class="mb-1 font-sans text-[11px] opacity-70">作者・書名（任意）</div>
+        <div class="font-serif font-semibold leading-snug clamp-2"
+             style="font-family: var(--font-serif);">
+          「いま心に残っている一文を、ここからふっと書き留めてみましょう。」
+        </div>
+        <div class="mt-3 text-right">
+          <span class="link link-primary">この下書きから作成 →</span>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- サマリ：小さな“本のカード” -->
-  <section class="mt-6 grid gap-4 sm:grid-cols-3" aria-label="サマリー">
-    <div class="rounded-2xl gh-glass p-5 relative hover-float">
+  <!-- ========== サマリ：触って気持ちいい小カード ========== -->
+  <section class="mt-6 grid gap-3 sm:gap-4 sm:grid-cols-3" aria-label="サマリー">
+    <div class="rounded-2xl gh-glass p-5 relative hover-float min-w-0">
       <div class="text-sm opacity-70">あなたのカード</div>
-      <div class="text-3xl font-extrabold mt-1" aria-live="polite"><%= @passages_count %></div>
+      <div class="text-3xl font-extrabold mt-1" aria-live="polite" data-countup="<%= @passages_count.to_i %>"><%= @passages_count %></div>
     </div>
-    <a href="<%= root_path %>#features" class="rounded-2xl gh-glass p-5 hover-float">
-      <div class="text-sm opacity-70">カスタマイズ</div>
-      <div class="mt-1">色・フォントで“言葉の表情”を変える</div>
+
+    <a href="<%= root_path %>#gallery" class="rounded-2xl gh-glass p-5 hover-float min-w-0">
+      <div class="text-sm opacity-70">ギャラリー</div>
+      <div class="mt-1 truncate">“言葉の表情”を眺める</div>
     </a>
-    <%= link_to edit_user_registration_path, class: "rounded-2xl gh-glass p-5 hover-float" do %>
+
+    <%= link_to edit_user_registration_path, class: "rounded-2xl gh-glass p-5 hover-float min-w-0" do %>
       <div class="text-sm opacity-70">プロフィール</div>
       <div class="mt-1 truncate"><%= current_user.email %></div>
     <% end %>
   </section>
 
-  <!-- 最近の一節 -->
-  <section class="mt-10" aria-labelledby="recent-title">
-    <div class="flex items-end justify-between">
-      <div>
+  <!-- ========== 最近の一節：等高＆崩れにくい ========== -->
+  <section class="mt-8 sm:mt-10" aria-labelledby="recent-title">
+    <div class="flex items-end justify-between gap-3 min-w-0">
+      <div class="min-w-0">
         <h2 id="recent-title" class="text-xl md:text-2xl font-bold gh-underline">最近の記録</h2>
-        <p class="opacity-70 text-sm mt-1">直近3枚のカードをピックアップ</p>
+        <p class="opacity-70 text-sm mt-1">直近のカードをピックアップ</p>
       </div>
-      <%= link_to passages_path, class: "link link-primary" do %>
+      <%= link_to passages_path, class: "link link-primary shrink-0" do %>
         すべて見る →
       <% end %>
     </div>
 
-    <% if @recent_passages.any? %>
-      <div class="mt-5 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+    <% if @recent_passages&.any? %>
+      <div class="mt-5 grid gap-4 sm:gap-5 sm:grid-cols-2 lg:grid-cols-3 auto-rows-fr">
         <% @recent_passages.each do |p| %>
-          <%= render "passages/card", passage: p, size: :mini %>
+          <div class="min-h-0">
+            <%= render "passages/card", passage: p, size: :mini %>
+          </div>
         <% end %>
       </div>
     <% else %>
-      <div class="mt-6 rounded-3xl gh-glass p-10 text-center hover-float">
+      <div class="mt-6 rounded-3xl gh-glass p-8 sm:p-10 text-center hover-float">
         <div class="text-4xl mb-2">🌿</div>
         <p class="font-semibold">まだカードがありません</p>
         <p class="opacity-70 text-sm mt-1">心に残った一文を、最初の1枚に。</p>
         <div class="mt-4">
-          <%= link_to new_passage_path, class: "btn btn-primary breeze" do %>
+          <%= link_to new_passage_path, class: "btn btn-primary breeze", data: { confetti: true } do %>
             ＋ 一節を記録
           <% end %>
         </div>
@@ -89,22 +124,140 @@
     <% end %>
   </section>
 
-  <!-- 使い方の3ポイント -->
-  <section class="mt-10 grid gap-4 md:grid-cols-3" aria-label="使い方">
-    <div class="rounded-2xl gh-glass p-6 hover-float">
+  <!-- ========== 使い方の3ポイント：モバイル→縦積み / SM→3列 ========== -->
+  <section class="mt-8 sm:mt-10 grid gap-3 sm:gap-4 md:grid-cols-3" aria-label="使い方">
+    <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
       <div class="text-2xl">✍️</div>
       <div class="font-bold mt-2">書き留める</div>
       <p class="opacity-75 text-sm mt-1">本文・著者・タイトルをサッと入力</p>
     </div>
-    <div class="rounded-2xl gh-glass p-6 hover-float">
+    <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
       <div class="text-2xl">🎨</div>
       <div class="font-bold mt-2">彩る</div>
-      <p class="opacity-75 text-sm mt-1">背景・文字色・フォントで個性を</p>
+      <p class="opacity-75 text-sm mt-1">配色プリセット＆フォントで小さな作品に</p>
     </div>
-    <div class="rounded-2xl gh-glass p-6 hover-float">
+    <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
       <div class="text-2xl">🗂️</div>
       <div class="font-bold mt-2">並べる</div>
       <p class="opacity-75 text-sm mt-1">あとで眺めて、また好きになる</p>
     </div>
   </section>
+
+  <!-- ========== モバイル下部ドック（片手で素早く） ========== -->
+  <nav class="md:hidden fixed inset-x-0 bottom-0 z-40">
+    <div class="mx-auto max-w-7xl px-4 pb-[calc(env(safe-area-inset-bottom)+8px)]">
+      <div class="rounded-2xl gh-glass p-2 flex items-center justify-around backdrop-blur">
+        <%= link_to new_passage_path, class: "btn btn-primary btn-sm", data: { confetti: true } do %>＋ 保存<% end %>
+        <%= link_to passages_path, class: "btn btn-ghost btn-sm" do %>一覧<% end %>
+        <%= link_to profile_path, class: "btn btn-ghost btn-sm" do %>プロフィール<% end %>
+        <%= link_to edit_user_registration_path, class: "btn btn-ghost btn-sm" do %>設定<% end %>
+      </div>
+    </div>
+  </nav>
 </div>
+
+<%# =========================
+    ページ専用スタイル（CSP nonce）
+    ========================= %>
+<style nonce="<%= content_security_policy_nonce %>">
+  /* 光のオーブ（淡く漂う） */
+  .qc-orb{position:absolute; border-radius:9999px; filter:blur(28px); opacity:.55; mix-blend-mode:screen; pointer-events:none;}
+  .qc-orb-1{top:-5rem; right:-5rem; width:22rem; height:22rem;
+    background: radial-gradient(45% 45% at 50% 50%, rgba(253,242,248,.65), transparent 60%);}
+  .qc-orb-2{bottom:-6rem; left:-6rem; width:18rem; height:18rem;
+    background: radial-gradient(45% 45% at 50% 50%, rgba(219,234,254,.6), transparent 60%);}
+  @media (min-width:768px){
+    .qc-orb-1{width:26rem;height:26rem;}
+    .qc-orb-2{width:22rem;height:22rem;}
+  }
+
+  /* ほのかなホタル */
+  .qc-fireflies{position:absolute; inset:0; overflow:hidden; pointer-events:none;}
+  .qc-fireflies span{position:absolute; width:6px; height:6px; border-radius:9999px;
+    background: radial-gradient(circle, rgba(255,255,255,.9) 0 40%, transparent 70%);
+    filter: blur(.5px); opacity:.7; animation: fly 7s linear infinite;}
+  .qc-fireflies span:nth-child(odd){width:5px;height:5px; animation-duration:8.5s; opacity:.6;}
+  @keyframes fly{
+    0%{ transform: translate(var(--sx, 10%), var(--sy, 10%)) scale(.8);}
+    50%{ transform: translate(calc(var(--sx, 10%) + 30%), calc(var(--sy, 10%) - 10%)) scale(1);}
+    100%{ transform: translate(var(--sx, 10%), var(--sy, 10%)) scale(.8);}
+  }
+  /* ランダムっぽい配置 */
+  .qc-fireflies span:nth-child(1){--sx:10%; --sy:30%;}
+  .qc-fireflies span:nth-child(2){--sx:28%; --sy:18%;}
+  .qc-fireflies span:nth-child(3){--sx:55%; --sy:24%;}
+  .qc-fireflies span:nth-child(4){--sx:72%; --sy:12%;}
+  .qc-fireflies span:nth-child(5){--sx:84%; --sy:36%;}
+  .qc-fireflies span:nth-child(6){--sx:14%; --sy:62%;}
+  .qc-fireflies span:nth-child(7){--sx:38%; --sy:70%;}
+  .qc-fireflies span:nth-child(8){--sx:66%; --sy:64%;}
+  .qc-fireflies span:nth-child(9){--sx:82%; --sy:58%;}
+  .qc-fireflies span:nth-child(10){--sx:50%; --sy:78%;}
+</style>
+
+<%# =========================
+    最小JS（CSP nonce付き）
+    - CountUp：数字に手応え
+    - Confetti：作成ボタンに小さな祝福
+    ========================= %>
+<script nonce="<%= content_security_policy_nonce %>">
+  (function () {
+    // ---- CountUp（トップ同等の軽量版）
+    var els = document.querySelectorAll('[data-countup]');
+    if ('IntersectionObserver' in window && els.length) {
+      var once = new WeakSet();
+      var io = new IntersectionObserver(function(entries){
+        entries.forEach(function(e){
+          if (!e.isIntersecting || once.has(e.target)) return;
+          once.add(e.target);
+          var el = e.target, end = parseInt(el.dataset.countup, 10) || 0;
+          var start = 0, dur = 900, t0 = performance.now();
+          function tick(t){
+            var p = Math.min(1, (t - t0) / dur);
+            el.textContent = Math.floor(start + (end - start) * p);
+            if (p < 1) requestAnimationFrame(tick);
+          }
+          requestAnimationFrame(tick);
+        });
+      }, {threshold: .3});
+      els.forEach(function(el){ io.observe(el); });
+    }
+
+    // ---- Confetti（依存なし／小さな紙吹雪）
+    function popConfetti(x, y){
+      var n = 18, container = document.createElement('div');
+      container.style.cssText = "position:fixed;left:0;top:0;width:100vw;height:100vh;pointer-events:none;z-index:60;overflow:hidden";
+      for (var i=0;i<n;i++){
+        var s = document.createElement('span');
+        var size = 6 + Math.random()*6;
+        var angle = Math.random()*360;
+        var dist = 80 + Math.random()*120;
+        var tx = Math.cos(angle*Math.PI/180) * dist;
+        var ty = Math.sin(angle*Math.PI/180) * dist;
+        s.style.cssText =
+          "position:absolute;left:"+x+"px;top:"+y+"px;width:"+size+"px;height:"+size+"px;border-radius:2px;"+
+          "background:hsl("+(Math.random()*360|0)+",90%,60%);"+
+          "transform:translate(-50%,-50%);opacity:.95;"+
+          "transition: transform .9s cubic-bezier(.22,1,.36,1), opacity .9s ease";
+        container.appendChild(s);
+        requestAnimationFrame((function(el,tx,ty){
+          return function(){
+            el.style.transform = "translate(calc(-50% + "+tx+"px), calc(-50% + "+ty+"px)) rotate("+ (Math.random()*540|0) +"deg)";
+            el.style.opacity = .0;
+          };
+        })(s,tx,ty));
+      }
+      document.body.appendChild(container);
+      setTimeout(function(){ container.remove(); }, 1000);
+    }
+
+    // ボタンに confetti を付与
+    document.querySelectorAll('[data-confetti]').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        var r = btn.getBoundingClientRect();
+        var x = r.left + r.width/2, y = r.top + r.height/2;
+        popConfetti(x, y);
+      }, {passive:true});
+    });
+  })();
+</script>

--- a/app/views/passages/_form.html.erb
+++ b/app/views/passages/_form.html.erb
@@ -1,3 +1,4 @@
+<%# ====== 色・フォントの初期スタイル ====== %>
 <% style_bg   = passage.customization&.bg_color.presence   || passage.bg_color.presence    || "#F9FAFB" %>
 <% style_text = passage.customization&.color.presence      || passage.text_color.presence  || "#111827" %>
 <% style_font = passage.customization&.font.presence       || passage.font_family.presence || "var(--font-serif)" %>
@@ -19,9 +20,7 @@
   <%# ====== 2カラム（md以上で分割 / スマホは1カラム） ====== %>
   <div class="grid gap-6 md:grid-cols-2 items-start">
     <%# ================= 左：入力カラム ================= %>
-    <%# ↓ このブロックに book-search コントローラを掛ける %>
     <div class="space-y-6">
-
       <!-- 本文 -->
       <div>
         <%= f.label :content, "一節本文", class: "block font-semibold mb-1" %>
@@ -30,7 +29,7 @@
               data: { preview_target: "content" } %>
       </div>
 
-      <!-- タイトル / 著者（入力で自動候補を出す） -->
+      <!-- タイトル / 著者 -->
       <div class="grid gap-4 md:grid-cols-2">
         <div>
           <%= f.label :title, "作品タイトル", class: "block font-semibold mb-1" %>
@@ -54,22 +53,17 @@
         </div>
       </div>
 
-      <!-- 書籍検索アクション（モーダル／クリア）＋ ISBN 直入力（任意） -->
+      <!-- 書籍検索アクション（モーダル／クリア）＋ ISBN -->
       <div class="flex flex-col gap-2">
         <div class="flex gap-2">
           <button type="button"
                   class="btn btn-outline btn-sm"
-                  data-action="click->book-search#open">
-            🔎 書籍を検索してセット
-          </button>
+                  data-action="click->book-search#open">🔎 書籍を検索してセット</button>
           <button type="button"
                   class="btn btn-ghost btn-sm"
-                  data-action="click->book-search#clear">
-            クリア
-          </button>
+                  data-action="click->book-search#clear">クリア</button>
         </div>
 
-        <%# BookInfo 側の ISBN を“検索兼ねる入力”として露出（任意） %>
         <div class="max-w-xs">
           <label class="label"><span class="label-text text-xs">ISBN（任意。入力で候補表示）</span></label>
           <%= f.fields_for :book_info do |bf| %>
@@ -82,7 +76,7 @@
         </div>
       </div>
 
-      <%# インライン候補の表示エリア（クリックでセット） %>
+      <%# インライン候補表示 %>
       <div class="mt-2" data-book-search-target="inlineResults"></div>
 
       <!-- 見た目のカスタマイズ（簡易） -->
@@ -176,29 +170,24 @@
 
       <!-- BookInfo（保存用 hidden と公開したい項目） -->
       <%= f.fields_for :book_info do |bf| %>
-  <%= bf.hidden_field :id if bf.object&.persisted? %>  <!-- これを追加 -->
-
-  <%= bf.hidden_field :title,          data: { "book-search-target": "title" } %>
-  <%= bf.hidden_field :author,         data: { "book-search-target": "author" } %>
-  <%= bf.hidden_field :published_date, data: { "book-search-target": "publishedDate" } %>
-  <%= bf.hidden_field :cover_url,      data: { "book-search-target": "coverUrl" } %>
-  <%= bf.hidden_field :publisher,      data: { "book-search-target": "publisher" } %>
-  <%= bf.hidden_field :page_count,     data: { "book-search-target": "pageCount" } %>
-  <%= bf.hidden_field :source,         data: { "book-search-target": "source" } %>
-  <%= bf.hidden_field :source_id,      data: { "book-search-target": "sourceId" } %>
-<% end %>
+        <%= bf.hidden_field :id if bf.object&.persisted? %>
+        <%= bf.hidden_field :title,          data: { "book-search-target": "title" } %>
+        <%= bf.hidden_field :author,         data: { "book-search-target": "author" } %>
+        <%= bf.hidden_field :published_date, data: { "book-search-target": "publishedDate" } %>
+        <%= bf.hidden_field :cover_url,      data: { "book-search-target": "coverUrl" } %>
+        <%= bf.hidden_field :publisher,      data: { "book-search-target": "publisher" } %>
+        <%= bf.hidden_field :page_count,     data: { "book-search-target": "pageCount" } %>
+        <%= bf.hidden_field :source,         data: { "book-search-target": "source" } %>
+        <%= bf.hidden_field :source_id,      data: { "book-search-target": "sourceId" } %>
+      <% end %>
 
       <!-- 詳細設定ページへの導線 -->
       <div class="mt-2">
         <% if passage.persisted? %>
           <% if passage.customization.present? %>
-            <%= link_to "見た目をカスタマイズ（詳細設定）",
-                  edit_passage_customization_path(passage),
-                  class: "btn btn-outline" %>
+            <%= link_to "見た目をカスタマイズ（詳細設定）", edit_passage_customization_path(passage), class: "btn btn-outline" %>
           <% else %>
-            <%= link_to "見た目をカスタマイズ（詳細設定）",
-                  new_passage_customization_path(passage),
-                  class: "btn btn-outline" %>
+            <%= link_to "見た目をカスタマイズ（詳細設定）", new_passage_customization_path(passage), class: "btn btn-outline" %>
           <% end %>
         <% else %>
           <button class="btn btn-outline" disabled>見た目をカスタマイズ（詳細設定）</button>
@@ -216,7 +205,7 @@
     </div>
 
     <%# ================= 右：PC用 sticky プレビュー ================= %>
-    <div class="hidden md:block md:sticky md:top-24">
+    <aside class="hidden md:block md:sticky md:top-24">
       <div class="mb-2">
         <h2 class="text-xl font-bold gh-underline">プレビュー</h2>
         <p class="text-sm opacity-70">入力に合わせて自動更新</p>
@@ -226,19 +215,28 @@
            class="relative rounded-2xl p-6 border gh-glass"
            style="background:<%= style_bg %>; color:<%= style_text %>; font-family:<%= style_font %>;">
         <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
-
         <div id="preview-meta-desktop" class="text-[11px] opacity-70 mb-1 font-sans">
           <% meta = [f.object.author.presence, f.object.title.presence&.yield_self { |t| "『#{t}』" }].compact.join(" ") %>
           <%= meta %>
         </div>
-        <div id="preview-content-desktop"
-             class="text-lg md:text-2xl font-semibold leading-relaxed whitespace-pre-wrap"></div>
+        <div id="preview-content-desktop" class="text-lg md:text-2xl font-semibold leading-relaxed whitespace-pre-wrap"></div>
       </div>
-    </div>
-  </div>
+    </aside>
+  </div> <!-- /grid -->
 <% end %>
 
-<%# ================= モバイル用：下固定ミニプレビューバー ================= %>
+<%# ====== デスクトップ用：追従ミニプレビュー FAB（右下に出たり消えたり） ====== %>
+<div id="preview-fab" class="hidden md:block fixed bottom-6 right-6 z-40 opacity-0 pointer-events-none transition-opacity duration-200">
+  <div id="preview-card-fab"
+       class="relative rounded-xl border gh-glass p-4 qc-fab shadow-xl"
+       style="background:<%= style_bg %>; color:<%= style_text %>; font-family:<%= style_font %>;">
+    <div class="absolute inset-0 gh-grain pointer-events-none rounded-xl"></div>
+    <div id="preview-meta-fab" class="text-[10px] opacity-70 mb-1 font-sans"></div>
+    <div id="preview-content-fab" class="text-sm font-semibold leading-snug clamp-3"></div>
+  </div>
+</div>
+
+<%# ====== モバイル用：下固定ミニプレビューバー ====== %>
 <div class="md:hidden fixed inset-x-0 bottom-0 z-40">
   <div class="mx-auto max-w-7xl px-4" style="padding-bottom: env(safe-area-inset-bottom);">
     <div class="rounded-xl border gh-glass p-3 shadow-lg backdrop-blur">
@@ -254,10 +252,9 @@
     </div>
   </div>
 </div>
-<%# モバイルで固定バーに隠れないよう余白を確保 %>
 <div class="h-28 md:hidden"></div>
 
-<%# ================= 書籍検索モーダル（必要なら使う） ================= %>
+<%# ====== 書籍検索モーダル（そのまま） ====== %>
 <dialog id="book-search-modal" class="modal">
   <div class="modal-box max-w-3xl">
     <h3 class="font-bold text-lg mb-4">書籍検索</h3>
@@ -279,37 +276,46 @@
   </form>
 </dialog>
 
-<%# ================= プレビュー反映スクリプト（PC/モバイル対応） ================= %>
-<script>
+<%# ====== 追加スタイル（FABサイズ＆クランプ） ====== %>
+<style nonce="<%= content_security_policy_nonce %>">
+  .qc-fab{ box-sizing:border-box; width: 320px; max-width: calc(100vw - 24px); height: 132px; }
+  @media (max-width: 1200px){ .qc-fab{ width: 300px; height: 124px; } }
+  .clamp-3{-webkit-line-clamp:3;display:-webkit-box;-webkit-box-orient:vertical;overflow:hidden}
+</style>
+
+<%# ====== プレビュー反映 + “見失ったらFAB”表示制御 ====== %>
+<script nonce="<%= content_security_policy_nonce %>">
 (function(){
   function setupPreview(){
     const form = document.getElementById("passage-form") || document.querySelector("form");
-    if (!form || form.dataset.previewBound === "1") return; // 二重バインド防止
+    if (!form || form.dataset.previewBound === "1") return;
     form.dataset.previewBound = "1";
 
-    // === ここから下は元の処理をそのまま移植（内容は変えない） ===
-
     // 入力
-    const title  = form.querySelector('[data-preview-target="title"]');
-    const author = form.querySelector('[data-preview-target="author"]');
-    const body   = form.querySelector('[data-preview-target="content"]');
-    const fontSel= form.querySelector('[data-preview-target="font"]');
-    const textInp= form.querySelector('[data-preview-target="textColor"]');
-    const bgInp  = form.querySelector('[data-preview-target="bgColor"]');
-    const textPick = form.querySelector('input[data-colorpicker="textColor"]');
-    const bgPick   = form.querySelector('input[data-colorpicker="bgColor"]');
+    const title   = form.querySelector('[data-preview-target="title"]');
+    const author  = form.querySelector('[data-preview-target="author"]');
+    const body    = form.querySelector('[data-preview-target="content"]');
+    const fontSel = form.querySelector('[data-preview-target="font"]');
+    const textInp = form.querySelector('[data-preview-target="textColor"]');
+    const bgInp   = form.querySelector('[data-preview-target="bgColor"]');
+    const textPick= form.querySelector('input[data-colorpicker="textColor"]');
+    const bgPick  = form.querySelector('input[data-colorpicker="bgColor"]');
 
-    // PC
+    // プレビュー要素（PC / Mobile / FAB）
     const cardD = document.getElementById('preview-card-desktop');
     const metaD = document.getElementById('preview-meta-desktop');
     const contD = document.getElementById('preview-content-desktop');
 
-    // モバイル
     const cardM = document.getElementById('preview-card-mobile');
     const metaM = document.getElementById('preview-meta-mobile');
     const contM = document.getElementById('preview-content-mobile');
 
-    const anyCard = cardD || cardM;
+    const fabWrap = document.getElementById('preview-fab');
+    const cardF = document.getElementById('preview-card-fab');
+    const metaF = document.getElementById('preview-meta-fab');
+    const contF = document.getElementById('preview-content-fab');
+
+    const anyCard = cardD || cardM || cardF;
     const FALLBACK = {
       font: (anyCard && anyCard.style.fontFamily) || "var(--font-serif)",
       text: (anyCard && anyCard.style.color)      || "#111827",
@@ -328,24 +334,20 @@
       const meta = [a, t ? `『${t}』` : null].filter(Boolean).join(" ");
       if (metaD) metaD.textContent = meta;
       if (metaM) metaM.textContent = meta;
+      if (metaF) metaF.textContent = meta;
     }
     function updateBody(){
       const v = (body?.value || "");
       if (contD) contD.textContent = v;
       if (contM) contM.textContent = v;
+      if (contF) contF.textContent = v;
     }
-    function applyStyleBoth(){ setCardStyle(cardD); setCardStyle(cardM); }
+    function applyStyleAll(){ setCardStyle(cardD); setCardStyle(cardM); setCardStyle(cardF); }
 
     function bindPair(textInput, colorInput){
       if (!textInput || !colorInput) return;
-      colorInput.addEventListener("input", e => {
-        textInput.value = e.target.value;
-        applyStyleBoth();
-      });
-      textInput.addEventListener("input", e => {
-        if (/^#/.test(e.target.value)) colorInput.value = e.target.value;
-        applyStyleBoth();
-      });
+      colorInput.addEventListener("input", e => { textInput.value = e.target.value; applyStyleAll(); });
+      textInput.addEventListener("input", e => { if (/^#/.test(e.target.value)) colorInput.value = e.target.value; applyStyleAll(); });
     }
 
     // クイックフォント
@@ -357,20 +359,16 @@
       });
     });
 
-    function rgbToHex(rgb) {
-      const m = rgb.match(/\d+/g);
-      if (!m) return "";
-      return "#" + m.slice(0, 3).map(n => ("0" + parseInt(n, 10).toString(16)).slice(-2)).join("");
-    }
-    function saveRecent(inputEl, hex) {
+    // 最近色の維持（ローカルストレージ）
+    function rgbToHex(rgb){ const m = rgb.match(/\d+/g); if(!m) return ""; return "#" + m.slice(0,3).map(n => ("0"+parseInt(n,10).toString(16)).slice(-2)).join(""); }
+    function saveRecent(inputEl, hex){
       if (!hex || !hex.startsWith("#")) return;
       const key = inputEl === textInp ? "recent_text" : "recent_bg";
       const arr = JSON.parse(localStorage.getItem(key) || "[]").filter(v => v !== hex);
-      arr.unshift(hex);
-      localStorage.setItem(key, JSON.stringify(arr.slice(0, 8)));
+      arr.unshift(hex); localStorage.setItem(key, JSON.stringify(arr.slice(0,8)));
       renderRecent();
     }
-    function renderRecent() {
+    function renderRecent(){
       const wrapText = form.querySelector('[data-recent="textColor"]');
       const wrapBg   = form.querySelector('[data-recent="bgColor"]');
       const make = (hex, key) => {
@@ -378,70 +376,75 @@
         b.type = "button"; b.title = hex;
         b.className = "size-6 rounded-full border";
         b.style.background = hex;
-        b.dataset.colorPreset = key;
-        b.dataset.value = hex;
         b.addEventListener("click", () => {
-          const text = key === "textColor" ? textInp : bgInp;
-          const pick = key === "textColor" ? textPick : bgPick;
-          if (text) text.value = hex;
+          const inp = key === "textColor" ? textInp : bgInp;
+          const pick= key === "textColor" ? textPick : bgPick;
+          if (inp)  inp.value = hex;
           if (pick) pick.value = hex;
-          applyStyleBoth(); saveRecent(text, hex);
+          applyStyleAll(); saveRecent(inp, hex);
         });
         return b;
       };
-      if (wrapText) {
-        wrapText.innerHTML = "";
-        (JSON.parse(localStorage.getItem("recent_text") || "[]"))
-          .forEach(hex => wrapText.appendChild(make(hex, "textColor")));
-      }
-      if (wrapBg) {
-        wrapBg.innerHTML = "";
-        (JSON.parse(localStorage.getItem("recent_bg") || "[]"))
-          .forEach(hex => wrapBg.appendChild(make(hex, "bgColor")));
-      }
+      if (wrapText){ wrapText.innerHTML = ""; (JSON.parse(localStorage.getItem("recent_text") || "[]")).forEach(hex => wrapText.appendChild(make(hex,"textColor"))); }
+      if (wrapBg){   wrapBg.innerHTML = "";   (JSON.parse(localStorage.getItem("recent_bg")   || "[]")).forEach(hex => wrapBg.appendChild(make(hex,"bgColor"))); }
     }
 
     form.querySelectorAll('[data-color-preset]').forEach(btn => {
       btn.addEventListener("click", (e) => {
         const key = e.currentTarget.dataset.colorPreset;
         const val = e.currentTarget.dataset.value;
-        const text = key === "textColor" ? textInp : bgInp;
-        const pick = key === "textColor" ? textPick : bgPick;
-        if (text) text.value = val;
+        const inp = key === "textColor" ? textInp : bgInp;
+        const pick= key === "textColor" ? textPick : bgPick;
+        if (inp)  inp.value = val;
         if (pick) pick.value = val;
-        applyStyleBoth(); saveRecent(text, val);
+        applyStyleAll(); saveRecent(inp, val);
       });
     });
     form.querySelectorAll('[data-clear-color]').forEach(btn => {
       btn.addEventListener("click", (e) => {
         const key = e.currentTarget.dataset.clearColor;
-        const text = key === "textColor" ? textInp : bgInp;
-        if (text) text.value = "";
-        applyStyleBoth();
+        const inp = key === "textColor" ? textInp : bgInp;
+        if (inp) inp.value = ""; applyStyleAll();
       });
     });
     form.querySelectorAll('[data-pick-current]').forEach(btn => {
       btn.addEventListener("click", (e) => {
         const key = e.currentTarget.dataset.pickCurrent;
-        const text = key === "textColor" ? textInp : bgInp;
-        const prop = key === "textColor" ? "color" : "backgroundColor";
-        const source = cardD || cardM;
+        const prop= key === "textColor" ? "color" : "backgroundColor";
+        const source = cardD || cardM || cardF;
         const val = source ? rgbToHex(getComputedStyle(source)[prop]) : "";
-        if (text && val) text.value = val;
-        const pick = key === "textColor" ? textPick : bgPick;
+        const inp = key === "textColor" ? textInp : bgInp;
+        const pick= key === "textColor" ? textPick : bgPick;
+        if (inp && val) inp.value = val;
         if (pick) pick.value = val;
-        applyStyleBoth(); saveRecent(text, val);
+        applyStyleAll(); saveRecent(inp, val);
       });
     });
 
     [title, author].forEach(el => el && el.addEventListener("input", updateMeta));
     body && body.addEventListener("input", updateBody);
-    fontSel && fontSel.addEventListener("change", applyStyleBoth);
+    fontSel && fontSel.addEventListener("change", applyStyleAll);
     bindPair(textInp, textPick);
-    bindPair(bgInp, bgPick);
+    bindPair(bgInp,   bgPick);
 
     // 初期表示
-    updateMeta(); updateBody(); applyStyleBoth(); renderRecent();
+    updateMeta(); updateBody(); applyStyleAll(); renderRecent();
+
+    // ★ デスクトップ：右プレビューが視界から消えたら FAB を表示
+    if ('IntersectionObserver' in window && cardD && fabWrap){
+      const io = new IntersectionObserver((entries) => {
+        entries.forEach(e => {
+          if (e.isIntersecting){
+            fabWrap.classList.add('opacity-0','pointer-events-none');
+            fabWrap.classList.remove('opacity-100');
+          }else{
+            fabWrap.classList.remove('opacity-0','pointer-events-none');
+            fabWrap.classList.add('opacity-100');
+          }
+        });
+      }, { root: null, threshold: 0.2 });
+      io.observe(cardD);
+    }
 
     // モバイル：展開/収納
     const toggleBtn = document.getElementById('toggle-mobile-preview');
@@ -455,7 +458,7 @@
     }
   }
 
-  // Turbo でも通常遷移でも確実に初期化
+  // Turbo 対応
   document.addEventListener("turbo:load",   setupPreview);
   document.addEventListener("turbo:render", setupPreview);
   if (document.readyState !== "loading") setupPreview();

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,134 +1,292 @@
 <section class="pt-8 sm:pt-10 md:pt-12">
   <div class="container mx-auto max-w-7xl px-4 md:px-8">
 
-    <!-- Hero -->
-    <div class="rounded-3xl gh-glass p-6 sm:p-8 md:p-10 relative overflow-hidden hover-float">
-      <!-- 光のにじみ：モバイルは非表示で軽量化 -->
+    <!-- =========================
+         Hero + ライブ・プレイグラウンド
+         ========================= -->
+    <div class="relative overflow-hidden rounded-3xl gh-glass p-6 sm:p-8 md:p-10 hover-float">
       <div class="pointer-events-none absolute -top-24 -right-24 size-80 rounded-full bg-gradient-to-tr from-amber-200/40 to-rose-200/40 blur-3xl hidden md:block"></div>
 
-      <div class="grid items-center gap-8 sm:gap-10 lg:grid-cols-2">
+      <div class="grid items-start gap-8 sm:gap-10 lg:grid-cols-2">
         <!-- 左：コピー & CTA -->
-        <div>
-          <div class="flex items-center gap-2 mb-3">
-            <span class="badge badge-primary">MVP</span>
+        <div class="flex flex-col">
+          <div class="mb-3 flex flex-wrap items-center gap-2">
+            <span class="badge badge-primary">β / MVP</span>
             <span class="badge badge-ghost">プライバシー重視</span>
+            <span class="badge badge-ghost">広告なし</span>
           </div>
 
-          <h1 class="font-serif text-fluid-3xl tracking-tight gh-underline gh-sparkle">
+          <h1 class="gh-underline gh-sparkle font-serif text-fluid-3xl tracking-tight text-balance">
             一節が、記憶になる。
           </h1>
 
-          <p class="mt-4 text-[15px] sm:text-base md:text-lg opacity-85 font-sans content-readable">
+          <p class="content-readable mt-4 font-sans text-[15px] opacity-85 sm:text-base md:text-lg">
             心に刺さった一節を、<b>著者・タイトル</b>と一緒に保存。<br>
             背景・文字色・フォントを<b>自分らしくカスタム</b>して、“言葉のカード”としてコレクション。<br>
             <span class="opacity-80">思考ログで「言葉 → 気づき」の連鎖も辿れます。</span>
           </p>
 
-          <div class="mt-6 sm:mt-8 flex flex-col sm:flex-row gap-3">
+          <div class="mt-6 flex flex-col gap-3 sm:mt-8 sm:flex-row">
             <% if user_signed_in? %>
-              <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-primary btn-press tap-target" %>
-              <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-outline btn-press underline-grow tap-target" %>
+              <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-primary" %>
+              <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-outline" %>
             <% else %>
-              <%= link_to "無料ではじめる", new_user_registration_path, class: "btn btn-primary btn-press tap-target" %>
-              <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline btn-press underline-grow tap-target" %>
+              <%= link_to "無料ではじめる", new_user_registration_path, class: "btn btn-primary" %>
+              <%= link_to "ログイン", new_user_session_path, class: "btn btn-outline" %>
             <% end %>
           </div>
-          <p class="mt-3 text-xs opacity-60 font-sans">登録は1分。広告なし・いつでも削除できます。</p>
+          <p class="mt-3 font-sans text-xs opacity-60">登録は1分。広告なし・いつでも削除できます。</p>
+
+          <!-- ベネフィット帯（等高化） -->
+          <div class="mt-6 grid grid-cols-3 gap-3 sm:gap-4 md:max-w-3xl">
+            <% [
+              { title: "秒速保存", body: "最短10秒で完了" },
+              { title: "見返したくなる", body: "美しいカード表示" },
+              { title: "深まる読書", body: "思考ログで振り返り" }
+            ].each do |b| %>
+              <div class="min-h-[74px] rounded-xl bg-base-100 p-3 shadow-sm flex flex-col">
+                <div class="text-sm font-bold"><%= b[:title] %></div>
+                <div class="mt-0.5 text-[13px] opacity-70"><%= b[:body] %></div>
+              </div>
+            <% end %>
+          </div>
         </div>
 
-        <!-- 右：プレビュー（紙カード風） -->
-        <div class="max-w-lg mx-auto w-full">
-          <div class="rounded-3xl gh-glass p-4 sm:p-6 md:p-8 relative overflow-hidden">
+        <!-- 右：ライブ・プレイグラウンド（固定高さで安定） -->
+        <div class="w-full max-w-lg mx-auto lg:justify-self-end self-start">
+          <div class="relative overflow-hidden rounded-3xl gh-glass p-4 sm:p-6 md:p-8 self-start">
             <div class="grid gap-4 sm:gap-5">
-              <!-- 大きめカード（1列固定） -->
-              <div class="relative rounded-2xl p-5 sm:p-6 border gh-paper overflow-hidden">
+              <!-- プレビューカード：固定高さ + 行数制限 -->
+              <div id="demo-card"
+                    class="relative overflow-hidden rounded-2xl border box-border p-4 sm:p-5 qc-demo-h flex flex-col"
+                    style="background:#FAF7F0; color:#111827; font-family: var(--font-serif);">
                 <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
-                <div class="text-[11px] opacity-70 mb-1 font-sans">夏目 漱石『こころ』</div>
-                <div class="card-text font-semibold font-serif text-balance break-words">
-                  「人は弱い。弱さを知るところから、やさしさが始まる。」
+                <div id="demo-meta" class="mb-1 font-sans text-[11px] opacity-70">作者・書名（任意）</div>
+                <div id="demo-quote" class="break-words font-serif font-semibold text-[15px] sm:text-base leading-snug clamp-3" aria-live="polite">
+                  「好きな一節をここに打ってみてください」
                 </div>
+                <button id="demo-random" type="button" class="btn btn-xs btn-ghost mt-auto self-end">
+                  ランダム見本
+                </button>
               </div>
 
-              <!-- 小さめカード：モバイル1列 / SM以上2列、等高化 -->
-              <div class="grid auto-rows-fr gap-3 sm:gap-4 sm:grid-cols-2">
-                <div
-                  class="relative rounded-2xl p-4 border overflow-hidden"
-                  style="background:#111827; color:#F9FAFB; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;"
-                >
-                  <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl opacity-40"></div>
-                  <div class="text-[10px] opacity-70 mb-1">太宰 治『走れメロス』</div>
-                  <div class="text-sm font-semibold break-words">メロスは激怒した。</div>
+              <!-- コントロール -->
+              <div class="grid gap-3 sm:gap-4">
+                <!-- 本文 / メタ -->
+                <div class="grid gap-2 sm:grid-cols-2">
+                  <label class="input input-bordered flex items-center gap-2">
+                    <span class="text-[11px] opacity-70">本文</span>
+                    <input id="ctl-quote" type="text" class="grow" placeholder="例）メロスは激怒した。" />
+                  </label>
+                  <label class="input input-bordered flex items-center gap-2">
+                    <span class="text-[11px] opacity-70">著者・書名</span>
+                    <input id="ctl-meta" type="text" class="grow" placeholder="例）太宰 治『走れメロス』" />
+                  </label>
                 </div>
 
-                <div
-                  class="relative rounded-2xl p-4 border gh-paper overflow-hidden"
-                  style="color:#065F46; font-family: var(--font-sans);"
-                >
-                  <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
-                  <div class="text-[10px] opacity-70 mb-1">川端 康成『雪国』</div>
-                  <div class="text-sm font-semibold break-words">国境の長いトンネルを抜けると雪国であった。</div>
+                <!-- 配色プリセット -->
+                <div>
+                  <div class="mb-1 text-[11px] opacity-70">配色</div>
+                  <div class="flex flex-wrap items-center gap-2">
+                    <% palettes = [
+                      { name:"紙", bg:"#FAF7F0", fg:"#111827" },
+                      { name:"夜", bg:"#111827", fg:"#F9FAFB" },
+                      { name:"薄紅", bg:"#FDF2F8", fg:"#4A044E" },
+                      { name:"翆", bg:"#ECFDF5", fg:"#065F46" },
+                      { name:"空", bg:"#DBEAFE", fg:"#1E3A8A" },
+                      { name:"生成", bg:"#F3F4F6", fg:"#111827" }
+                    ] %>
+                    <% palettes.each do |p| %>
+                      <button type="button"
+                              class="btn btn-sm"
+                              data-bg="<%= p[:bg] %>" data-fg="<%= p[:fg] %>">
+                        <span class="mr-2 inline-block size-3 rounded-full"
+                              style="background:<%= p[:bg] %>; border:1px solid rgba(0,0,0,.08)"></span>
+                        <%= p[:name] %>
+                      </button>
+                    <% end %>
+                  </div>
+                </div>
+
+                <!-- フォント -->
+                <div>
+                  <div class="mb-1 text-[11px] opacity-70">フォント</div>
+                  <div class="join">
+                    <input class="join-item btn btn-sm" type="radio" name="font"
+                           aria-label="Serif" data-font="var(--font-serif)" checked>
+                    <input class="join-item btn btn-sm" type="radio" name="font"
+                           aria-label="Sans"  data-font="var(--font-sans)">
+                    <input class="join-item btn btn-sm" type="radio" name="font"
+                           aria-label="Mono"  data-font='ui-monospace, SFMono-Regular, Menlo, monospace'>
+                  </div>
+                </div>
+
+                <!-- すぐ試す -->
+                <div class="text-center">
+                  <% if user_signed_in? %>
+                    <%= link_to "この設定で記録をはじめる →", new_passage_path, class: "link link-primary" %>
+                  <% else %>
+                    <%= link_to "アカウントを作成して保存する →", new_user_registration_path, class: "link link-primary" %>
+                  <% end %>
                 </div>
               </div>
-
-              <p class="text-xs opacity-60 font-sans content-readable mx-auto">
-                * 入力内容に合わせてバランスよくレイアウトされます
-              </p>
             </div>
           </div>
         </div>
-      </div>
-    </div>
+      </div><!-- /grid -->
+    </div><!-- /hero -->
 
-    <!-- How it works（3ステップ） -->
-    <section id="how" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
-      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">使い方はシンプル</h2>
-      <p class="text-center opacity-70 mt-2 font-sans">5分で “あなたの本棚” ができあがる</p>
+    <!-- =========================
+         How it works（コンパクト安定版）
+         ========================= -->
+    <section id="how" class="scroll-mt-24 py-12 sm:py-14 md:py-16">
+      <h2 class="gh-underline text-center font-serif text-fluid-2xl font-bold">
+        使い方はかんたん、でも奥深い
+      </h2>
+      <p class="mt-2 text-center font-sans opacity-70">
+        3ステップで “言葉のカード” が完成
+      </p>
 
-      <div class="mt-8 grid gap-4 sm:gap-5 md:grid-cols-3">
-        <%[
-          {n:"1", title:"一節を入力", body:"本文・著者・タイトルをサッと記録"},
-          {n:"2", title:"書誌を補完", body:"「書籍を検索」で書影や出版情報を取得"},
-          {n:"3", title:"彩って保存", body:"背景・文字色・フォントを選んでカード化"}
-        ].each do |s| %>
-          <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
-            <div class="size-8 rounded-full bg-base-300 flex items-center justify-center font-bold"><%= s[:n] %></div>
-            <h3 class="mt-3 font-bold text-lg font-sans"><%= s[:title] %></h3>
-            <p class="opacity-80 mt-1 text-sm font-sans content-readable"><%= s[:body] %></p>
+      <div class="mt-8 grid gap-6 md:grid-cols-12">
+        <!-- ステップ -->
+        <ol class="steps steps-vertical md:steps-horizontal md:col-span-7 lg:col-span-8">
+          <li class="step step-primary">
+            <div class="mt-2">
+              <div class="font-bold">一節を入力</div>
+              <p class="text-sm opacity-75">本文・著者・タイトルをサッと記録</p>
+            </div>
+          </li>
+          <li class="step step-primary">
+            <div class="mt-2">
+              <div class="font-bold">書誌を補完</div>
+              <p class="text-sm opacity-75">「書籍を検索」で書影や出版情報を取得</p>
+            </div>
+          </li>
+          <li class="step step-primary">
+            <div class="mt-2">
+              <div class="font-bold">彩って保存</div>
+              <p class="text-sm opacity-75">背景・文字色・フォントを選んでカード化</p>
+            </div>
+          </li>
+        </ol>
+
+        <!-- デモ＋箇条書き -->
+        <div class="md:col-span-5 lg:col-span-4 space-y-4">
+          <div class="relative rounded-xl border overflow-hidden gh-paper">
+            <div class="absolute inset-0 gh-grain pointer-events-none rounded-xl"></div>
+            <div class="p-4">
+              <div class="mb-1 font-sans text-[11px] opacity-70">夏目 漱石『こころ』</div>
+              <div class="font-serif font-semibold leading-snug text-[15px] sm:text-base clamp-3">
+                「人は弱い。弱さを知るところから、やさしさが始まる。」
+              </div>
+            </div>
           </div>
-        <% end %>
+
+          <ul class="space-y-2 text-sm opacity-85">
+            <li class="flex items-start gap-2"><span class="status"></span>書籍検索で <span class="font-semibold">書影・出版社・出版年</span> を自動補完</li>
+            <li class="flex items-start gap-2"><span class="status"></span><span class="font-semibold">配色プリセット＋自由入力</span> で好きな雰囲気に</li>
+            <li class="flex items-start gap-2"><span class="status"></span><span class="font-semibold">思考ログ</span> で気づきが連鎖していく</li>
+          </ul>
+        </div>
       </div>
 
-      <div class="mt-6 text-center">
-        <%= link_to "詳しい使い方を見る →", guide_path, class: "link link-primary tap-target" %>
+      <!-- ミニ統計 -->
+      <div class="mt-8 stats stats-vertical sm:stats-horizontal bg-base-100 shadow rounded-2xl w-full overflow-hidden qc-stats">
+        <div class="stat">
+          <div class="stat-title">最短保存</div>
+          <div class="stat-value"><span data-countup="10">10</span> 秒</div>
+          <div class="stat-desc opacity-75">本文→保存まで（目安）</div>
+        </div>
+        <div class="stat">
+          <div class="stat-title">配色プリセット</div>
+          <div class="stat-value"><span data-countup="6">6</span> 種</div>
+          <div class="stat-desc opacity-75">自由指定も対応</div>
+        </div>
+        <div class="stat">
+          <div class="stat-title">書誌連携</div>
+          <div class="stat-value">対応</div>
+          <div class="stat-desc opacity-75">検索で自動補完</div>
+        </div>
       </div>
     </section>
 
-    <!-- Features -->
-    <section id="features" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
-      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">QuoteCanvas の特徴</h2>
-      <p class="text-center opacity-70 mt-2 font-sans">“続けたくなる理由”がここに</p>
+    <!-- =========================
+         Features（差別化ポイント）
+         ========================= -->
+    <section id="features" class="scroll-mt-24 py-12 sm:py-14 md:py-16">
+      <h2 class="gh-underline text-center font-serif text-fluid-2xl font-bold">
+        なぜ QuoteCanvas なのか
+      </h2>
+      <p class="mt-2 text-center font-sans opacity-70">メモでは届かない、“見返したくなる” 体験</p>
 
-      <div class="mt-8 grid gap-5 sm:gap-6 md:grid-cols-3">
-        <%[
-          {icon:"📌", title:"秒速で記録",  body:"忘れないうちに保存。最低限の入力でOK。"},
-          {icon:"🧠", title:"思考ログ",    body:"気づきや連想を時系列に残し、後で辿れる。"},
-          {icon:"🎨", title:"カードとして美しい", body:"色・フォントを自由に。眺める体験が楽しい。"}
-        ].each do |f| %>
-          <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
-            <div class="text-3xl"><%= f[:icon] %></div>
-            <h3 class="mt-3 font-bold text-xl font-sans"><%= f[:title] %></h3>
-            <p class="opacity-80 mt-2 text-sm font-sans content-readable"><%= f[:body] %></p>
+      <div class="mt-8 grid gap-6 md:grid-cols-3">
+        <!-- ★ 修正：オーバーレイは absolute、親に relative -->
+        <article class="rounded-2xl gh-surface p-5 sm:p-6 hover-float flex flex-col">
+          <div class="text-xl">🎨 カードは“小さな作品”に</div>
+          <p class="mt-2 text-sm opacity-80">
+            配色プリセットとフォントで、言葉の印象までデザイン。あとから編集もOK。
+          </p>
+          <div class="relative mt-4 rounded-xl border overflow-hidden">
+            <div class="absolute inset-0 gh-grain pointer-events-none"></div>
+            <div class="grid place-items-center text-center p-4 "
+                 style="background:#FDF2F8;color:#4A044E;font-family:var(--font-serif)">
+              <div class="mb-1 font-sans text-[11px] opacity-70">与謝野晶子『みだれ髪』</div>
+              <div class="font-semibold leading-relaxed clamp-2">その手をば柔らかにして我に触れよ</div>
+            </div>
           </div>
-        <% end %>
+          <ul class="mt-4 list-disc space-y-1 pl-5 text-sm opacity-85">
+            <li>プリセット6種＋自由指定（色コードOK）</li>
+            <li>フォント：Serif / Sans / Mono</li>
+            <li>カードは自動整列＆崩れにくい設計</li>
+          </ul>
+        </article>
+
+        <article class="rounded-2xl gh-surface p-5 sm:p-6 hover-float">
+          <div class="text-xl">🧠 思考ログで “後から効く”</div>
+          <p class="mt-2 text-sm opacity-80">
+            一節から生まれた気づきや連想を、カードに紐づけて時系列に保存。
+          </p>
+          <div class="mt-4 rounded-xl border bg-base-100 p-4 space-y-2">
+            <div class="flex items-start gap-2"><span class="status"></span><div class="text-sm">“なぜ惹かれた？”を言語化 → 行動のヒントに</div></div>
+            <div class="flex items-start gap-2"><span class="status"></span><div class="text-sm">後日見返して理解が深まるサイクル</div></div>
+            <div class="flex items-start gap-2"><span class="status"></span><div class="text-sm">ログは自分専用。公開は任意</div></div>
+          </div>
+          <ul class="mt-4 list-disc space-y-1 pl-5 text-sm opacity-85">
+            <li>編集履歴／時系列で変化が追える</li>
+            <li>検索・フィルタ（将来拡張）</li>
+          </ul>
+        </article>
+
+        <article class="rounded-2xl gh-surface p-5 sm:p-6 hover-float">
+          <div class="text-xl">🔒 続けやすさとプライバシー</div>
+          <p class="mt-2 text-sm opacity-80">
+            広告なし。あなたのデータはあなたのもの。削除もエクスポートもいつでも。
+          </p>
+          <div class="mt-4 grid gap-3">
+            <div class="rounded-xl bg-base-100 p-3"><div class="text-sm font-bold">プライベート保存</div><div class="text-sm opacity-75">初期は非公開・共有はワンタップ</div></div>
+            <div class="rounded-xl bg-base-100 p-3"><div class="text-sm font-bold">軽快なUI</div><div class="text-sm opacity-75">モバイル最適化・最短手数で保存</div></div>
+            <div class="rounded-xl bg-base-100 p-3"><div class="text-sm font-bold">運用透明性</div><div class="text-sm opacity-75">データの扱いを明文化（ポリシー公開）</div></div>
+          </div>
+          <div class="mt-4">
+            <%= link_to "ポリシーを見る →", policy_path, class: "link link-primary" rescue nil %>
+          </div>
+        </article>
       </div>
     </section>
 
-    <!-- Gallery -->
-    <section id="gallery" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
-      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">カード・ギャラリー</h2>
-      <p class="text-center opacity-70 mt-2 font-sans">“言葉の表情”は、色とフォントで変わる</p>
+    <!-- =========================
+         Gallery（等高レイアウト版）
+         ========================= -->
+    <section id="gallery" class="scroll-mt-24 py-12 sm:py-14 md:py-16">
+      <div class="flex items-end justify-between gap-3">
+        <div>
+          <h2 class="gh-underline font-serif text-fluid-2xl font-bold">カード・ギャラリー</h2>
+          <p class="mt-2 font-sans opacity-70">“言葉の表情”は、色とフォントで変わる</p>
+        </div>
+        <button id="gallery-shuffle" class="btn btn-sm btn-ghost">シャッフル</button>
+      </div>
 
-      <div class="mt-8 grid gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div id="gallery-grid" class="mt-8 grid gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-3">
         <% samples = [
           {bg:"#FDF2F8", fg:"#4A044E", font:"var(--font-serif)",    meta:"与謝野晶子『みだれ髪』", body:"その手をば柔らかにして我に触れよ"},
           {bg:"#111827", fg:"#F9FAFB", font:"ui-monospace,SFMono-Regular,Menlo,monospace", meta:"太宰 治『走れメロス』", body:"メロスは激怒した。"},
@@ -138,54 +296,186 @@
           {bg:"#F3F4F6", fg:"#111827", font:"var(--font-serif)",     meta:"宮沢 賢治『雨ニモマケズ』", body:"雨ニモマケズ 風ニモマケズ"}
         ] %>
         <% samples.each do |c| %>
-          <div class="relative rounded-2xl p-5 sm:p-6 border overflow-hidden"
+          <div class="gallery-item relative overflow-hidden rounded-2xl border p-5 sm:p-6 flex flex-col"
                style="background:<%= c[:bg] %>; color:<%= c[:fg] %>; font-family:<%= c[:font] %>;">
             <div class="absolute inset-0 gh-grain pointer-events-none rounded-2xl"></div>
-            <div class="text-[11px] opacity-70 mb-1 font-sans"><%= c[:meta] %></div>
-            <div class="text-base sm:text-lg font-semibold leading-relaxed break-words"><%= c[:body] %></div>
+            <div class="mb-1 font-sans text-[11px] opacity-70"><%= c[:meta] %></div>
+            <div class="text-base font-semibold leading-relaxed sm:text-lg break-words clamp-3"><%= c[:body] %></div>
+            <div class="mt-auto"></div>
           </div>
         <% end %>
       </div>
     </section>
 
-    <!-- Roadmap -->
-    <section id="roadmap" class="scroll-mt-24 py-10 sm:py-12 md:py-14">
-      <h2 class="text-fluid-2xl font-bold text-center font-serif gh-underline">これから</h2>
-      <p class="text-center opacity-70 mt-2 font-sans">MVP後に予定しているアップデート</p>
+    <!-- =========================
+         Use Cases
+         ========================= -->
+    <section id="usecases" class="scroll-mt-24 py-12 sm:py-14 md:py-16">
+      <h2 class="gh-underline text-center font-serif text-fluid-2xl font-bold">使いどころ、いろいろ</h2>
+      <p class="mt-2 text-center font-sans opacity-70">あなたのワークフローにぴったりハマる3例</p>
 
-      <div class="mt-8 grid gap-5 sm:gap-6 md:grid-cols-3">
-        <%[
-          {title:"テーマ切替", body:"気分でダーク／ライトや配色テーマを選択。"},
-          {title:"タグと検索", body:"タグ付けとキーワードで、欲しい一節を素早く発見。"},
-          {title:"タグ機能の強化", body:"おすすめタグ・一括編集・並び替えで整理しやすく。"}
-        ].each do |f| %>
-          <div class="rounded-2xl gh-glass p-5 sm:p-6 hover-float">
-            <h3 class="font-bold text-xl font-sans"><%= f[:title] %></h3>
-            <p class="opacity-80 mt-2 text-sm font-sans content-readable"><%= f[:body] %></p>
-          </div>
+      <div class="mx-auto mt-8 grid max-w-5xl gap-5 sm:gap-6 md:grid-cols-3">
+        <article class="rounded-2xl gh-surface p-5 sm:p-6 hover-float flex flex-col min-h-[230px]">
+          <header class="text-lg font-bold">📚 読書メモを“作品化”</header>
+          <ul class="mt-2 list-disc pl-5 text-sm opacity-85 space-y-1">
+            <li>一節を保存 → 配色＆フォントでカード化</li>
+            <li>気づきを追記して理解を深める</li>
+            <li>後で並べて眺め、比較・発見に</li>
+          </ul>
+          <div class="mt-auto pt-3"><a href="#gallery" class="link link-primary">ギャラリーを見る →</a></div>
+        </article>
+
+        <article class="rounded-2xl gh-surface p-5 sm:p-6 hover-float flex flex-col min-h-[230px]">
+          <header class="text-lg font-bold">📝 研究・引用の整理</header>
+          <ul class="mt-2 list-disc pl-5 text-sm opacity-85 space-y-1">
+            <li>書誌情報を検索で補完して正確に</li>
+            <li>タグでテーマ横断の引用集に</li>
+            <li>発表用にカードを書き出し（将来）</li>
+          </ul>
+          <div class="mt-auto pt-3"><a href="#how" class="link link-primary">使い方を確認 →</a></div>
+        </article>
+
+        <article class="rounded-2xl gh-surface p-5 sm:p-6 hover-float flex flex-col min-h-[230px]">
+          <header class="text-lg font-bold">🎯 クリエイティブの種に</header>
+          <ul class="mt-2 list-disc pl-5 text-sm opacity-85 space-y-1">
+            <li>心に刺さった一節からアイデア発火</li>
+            <li>思考ログで発想の連鎖を可視化</li>
+            <li>色でムードボード的に並べ替え</li>
+          </ul>
+          <div class="mt-auto pt-3"><a href="#features" class="link link-primary">特徴を読む →</a></div>
+        </article>
+      </div>
+    </section>
+
+    <!-- =========================
+         FAQ
+         ========================= -->
+    <section id="faq" class="scroll-mt-24 py-12 sm:py-14 md:py-16">
+      <h2 class="gh-underline text-center font-serif text-fluid-2xl font-bold">よくある質問</h2>
+      <div class="mx-auto mt-6 max-w-3xl space-y-3">
+        <% faqs = [
+          {q:"データは公開されますか？", a:"初期設定は非公開です。共有は任意で、いつでも取り消せます。"},
+          {q:"広告は出ますか？", a:"出ません。読みやすさと集中を大切にしています。"},
+          {q:"スマホでも使えますか？", a:"もちろん。片手で素早く保存できるUIです。"},
+          {q:"後から編集できますか？", a:"カードの色・フォント、メモ、タグなどを編集できます。"}
+        ] %>
+        <% faqs.each do |f| %>
+          <details class="rounded-2xl gh-glass p-5">
+            <summary class="cursor-pointer text-lg font-bold"><%= f[:q] %></summary>
+            <p class="mt-2 font-sans opacity-80"><%= f[:a] %></p>
+          </details>
         <% end %>
       </div>
     </section>
 
-    <!-- CTA -->
-    <section class="py-10 sm:py-12 md:py-14">
-      <div class="rounded-3xl bg-gradient-to-r from-primary to-secondary text-primary-content p-6 sm:p-8 md:p-10 text-center shadow-xl hover-float">
-        <h2 class="font-serif text-3xl md:text-4xl font-extrabold tracking-tight text-balance">さぁ、一節をカードにしよう。</h2>
-        <p class="mt-2 opacity-90 font-sans">言葉を集める。自分の色で、記憶にする。</p>
-
-        <div class="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
+    <!-- =========================
+         CTA（締め）
+         ========================= -->
+    <section class="py-12 sm:py-14 md:py-16">
+      <div class="hover-float rounded-3xl bg-gradient-to-r from-primary to-secondary p-6 text-center text-primary-content shadow-xl sm:p-8 md:p-10">
+        <h2 class="text-balance font-serif text-3xl font-extrabold tracking-tight md:text-4xl">さぁ、一節をカードにしよう。</h2>
+        <p class="mt-2 font-sans opacity-90">言葉を集める。自分の色で、記憶にする。</p>
+        <div class="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
           <% if user_signed_in? %>
-            <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-secondary btn-press tap-target" %>
-            <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-ghost btn-press underline-grow tap-target" %>
+            <%= link_to "ダッシュボードへ", dashboard_path, class: "btn btn-secondary" %>
+            <%= link_to "＋ 一節を記録", new_passage_path, class: "btn btn-ghost" %>
           <% else %>
-            <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-secondary btn-press tap-target" %>
-            <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost btn-press underline-grow tap-target" %>
+            <%= link_to "無料で始める", new_user_registration_path, class: "btn btn-secondary" %>
+            <%= link_to "ログイン", new_user_session_path, class: "btn btn-ghost" %>
           <% end %>
         </div>
-
-        <p class="mt-3 text-xs opacity-80 font-sans">データはあなた専用。共有は任意です。</p>
+        <p class="mt-3 font-sans text-xs opacity-80">データはあなた専用。共有は任意です。</p>
       </div>
     </section>
 
   </div>
 </section>
+
+<!-- ====== ページ下部：最小JS（CSP nonce付き） ====== -->
+<script nonce="<%= content_security_policy_nonce %>">
+  (function () {
+    // -------- Playground ----------
+    var card = document.getElementById('demo-card');
+    if (card) {
+      var q  = document.getElementById('ctl-quote');
+      var m  = document.getElementById('ctl-meta');
+      var dq = document.getElementById('demo-quote');
+      var dm = document.getElementById('demo-meta');
+
+      q && q.addEventListener('input', function(){
+        dq.textContent = this.value || "「好きな一節をここに打ってみてください」";
+      });
+      m && m.addEventListener('input', function(){
+        dm.textContent = this.value || "作者・書名（任意）";
+      });
+
+      // palette buttons
+      document.querySelectorAll('[data-bg][data-fg]').forEach(function(btn){
+        btn.addEventListener('click', function(){
+          card.style.background = this.dataset.bg;
+          card.style.color = this.dataset.fg;
+        });
+      });
+
+      // font radios
+      document.querySelectorAll('input[name="font"][data-font]').forEach(function(r){
+        r.addEventListener('change', function(){
+          if (this.checked) {
+            card.style.fontFamily = this.dataset.font;
+            dq.style.fontFamily   = this.dataset.font;
+          }
+        });
+      });
+
+      // ランダム見本
+      var randomBtn = document.getElementById('demo-random');
+      var samples = [
+        { meta:"太宰 治『走れメロス』", quote:"メロスは激怒した。", bg:"#111827", fg:"#F9FAFB", font:'ui-monospace, SFMono-Regular, Menlo, monospace' },
+        { meta:"川端 康成『雪国』",     quote:"国境の長いトンネルを抜けると雪国であった。", bg:"#ECFDF5", fg:"#065F46", font:'var(--font-sans)' },
+        { meta:"与謝野晶子『みだれ髪』", quote:"その手をば柔らかにして我に触れよ", bg:"#FDF2F8", fg:"#4A044E", font:'var(--font-serif)' },
+      ];
+      randomBtn && randomBtn.addEventListener('click', function(){
+        var s = samples[Math.floor(Math.random()*samples.length)];
+        card.style.background = s.bg; card.style.color = s.fg;
+        card.style.fontFamily = s.font; dq.style.fontFamily = s.font;
+        dm.textContent = s.meta; dq.textContent = s.quote;
+      });
+    }
+
+    // -------- Stats：CountUp ----------
+    var els = document.querySelectorAll('[data-countup]');
+    if ('IntersectionObserver' in window && els.length) {
+      var once = new WeakSet();
+      var io = new IntersectionObserver(function(entries){
+        entries.forEach(function(e){
+          if (!e.isIntersecting || once.has(e.target)) return;
+          once.add(e.target);
+          var el = e.target, end = parseInt(el.dataset.countup, 10) || 0;
+          var start = 0, dur = 800, t0 = performance.now();
+          function tick(t){
+            var p = Math.min(1, (t - t0) / dur);
+            var val = Math.floor(start + (end - start) * p);
+            el.textContent = val;
+            if (p < 1) requestAnimationFrame(tick);
+          }
+          requestAnimationFrame(tick);
+        });
+      }, {threshold: .3});
+      els.forEach(function(el){ io.observe(el); });
+    }
+
+    // -------- Gallery：シャッフル ----------
+    var grid = document.getElementById('gallery-grid');
+    var shuffleBtn = document.getElementById('gallery-shuffle');
+    shuffleBtn && shuffleBtn.addEventListener('click', function(){
+      if (!grid) return;
+      var items = Array.from(grid.querySelectorAll('.gallery-item'));
+      for (var i = items.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        grid.appendChild(items[j]);
+        items.splice(j, 1);
+      }
+      this.blur();
+    });
+  })();
+</script>


### PR DESCRIPTION
## 概要
- 入力フォームを縦スクロールしてもプレビューが見えなくなる問題を解消し、編集体験を向上しました。
- ダッシュボード〜編集画面の世界観・操作感を統一して、初見でもワクワクするUIへ。

## 変更点
- 編集フォーム（passages#new / #edit）
  - 右カラムのプレビューが視界外になった時だけ出る 追従ミニプレビュー（FAB） を追加（IntersectionObserverで制御）
  - モバイル下部固定ミニプレビューを実装（展開/収納トグル付き）
  - プレビューは デスクトップ・モバイル・FAB の3箇所が同時に同期更新
  - 色・フォントのカスタム：最近使った色のローカル保存、ワンタップ適用を実装
  - Turbo 再描画でも二重バインドしないよう data-previewBound で防止
- UI/スタイル
  - .qc-fab（FABサイズ）と .clamp-3（3行クランプ）を追加
  - ガラス/グレイン等の質感は既存トークンに準拠して統一
- アクセシビリティ
  - プレビュー領域は視覚的だけでなく テキスト更新で反映（スクリーンリーダーで内容把握可能）
  - フォーカス可視化は既存の :focus-visible を踏襲
  
  